### PR TITLE
Add support for passing full event definitions

### DIFF
--- a/packages/amqp/README.md
+++ b/packages/amqp/README.md
@@ -2,8 +2,7 @@
 
 The library provides support for both direct exchanges and topic exchanges.
 
-> **_NOTE:_**  Check [README.md](../../README.md) for transport-agnostic library documentation.
->
+> **_NOTE:_** Check [README.md](../../README.md) for transport-agnostic library documentation.
 
 ## Publishers
 
@@ -25,42 +24,44 @@ Example:
 
 ```ts
 export const TEST_AMQP_CONFIG: AmqpConfig = {
-    vhost: '',
-    hostname: 'localhost',
-    username: 'guest',
-    password: 'guest',
-    port: 5672,
-    useTls: false,
+  vhost: '',
+  hostname: 'localhost',
+  username: 'guest',
+  password: 'guest',
+  port: 5672,
+  useTls: false,
 }
 
 const amqpConnectionManager = new AmqpConnectionManager(config, logger)
 await amqpConnectionManager.init()
 
 const publisher = new TestAmqpPublisher(
-    { amqpConnectionManager },
-    {
-        // other amqp options
-    })
+  { amqpConnectionManager },
+  {
+    // other amqp options
+  },
+)
 await publisher.init()
 
 const consumer = new TestAmqpConsumer(
-    { amqpConnectionManager },
-    {
-        // other amqp options
-    })
+  { amqpConnectionManager },
+  {
+    // other amqp options
+  },
+)
 await consumer.start()
 
 // break connection, to simulate unexpected disconnection in production
 await (await amqpConnectionManager.getConnection()).close()
 
-const message = { 
-    // some test message
+const message = {
+  // some test message
 }
 
 // This will fail, but will trigger reconnection within amqpConnectionManager
 publisher.publish(message)
-    
-// eventually connection is reestablished and propagated across all the AMQP services that use same amqpConnectionManager 
+
+// eventually connection is reestablished and propagated across all the AMQP services that use same amqpConnectionManager
 
 // This will succeed and consumer, which also received new connection, will be able to consume it
 publisher.publish(message)

--- a/packages/amqp/lib/AbstractAmqpConsumer.ts
+++ b/packages/amqp/lib/AbstractAmqpConsumer.ts
@@ -8,13 +8,9 @@ import type {
   QueueConsumer,
   QueueConsumerOptions,
   TransactionObservabilityManager,
-} from '@message-queue-toolkit/core'
-import {
-  isMessageError,
-  parseMessage,
-  HandlerContainer,
   MessageSchemaContainer,
 } from '@message-queue-toolkit/core'
+import { isMessageError, parseMessage, HandlerContainer } from '@message-queue-toolkit/core'
 import type { Connection, Message } from 'amqplib'
 
 import type {

--- a/packages/amqp/lib/AbstractAmqpConsumer.ts
+++ b/packages/amqp/lib/AbstractAmqpConsumer.ts
@@ -100,11 +100,8 @@ export abstract class AbstractAmqpConsumer<
       ? options.locatorConfig.queueName
       : options.creationConfig!.queueName
 
-    const messageSchemas = options.handlers.map((entry) => entry.schema)
-    this.messageSchemaContainer = new MessageSchemaContainer<MessagePayloadType>({
-      messageSchemas,
-      messageTypeField: options.messageTypeField,
-    })
+    this.messageSchemaContainer = this.resolveConsumerMessageSchemaContainer(options)
+
     this.handlerContainer = new HandlerContainer<
       MessagePayloadType,
       ExecutionContext,

--- a/packages/amqp/lib/AbstractAmqpPublisher.ts
+++ b/packages/amqp/lib/AbstractAmqpPublisher.ts
@@ -4,11 +4,12 @@ import type {
   BarrierResult,
   CommonCreationConfigType,
   MessageInvalidFormatError,
+  MessageSchemaContainer,
   MessageValidationError,
   QueuePublisherOptions,
   SyncPublisher,
 } from '@message-queue-toolkit/core'
-import { objectToBuffer, MessageSchemaContainer } from '@message-queue-toolkit/core'
+import { objectToBuffer } from '@message-queue-toolkit/core'
 import type { ZodSchema } from 'zod'
 
 import type { AMQPDependencies } from './AbstractAmqpService'

--- a/packages/amqp/lib/AbstractAmqpPublisher.ts
+++ b/packages/amqp/lib/AbstractAmqpPublisher.ts
@@ -49,11 +49,7 @@ export abstract class AbstractAmqpPublisher<
   ) {
     super(dependencies, options)
 
-    const messageSchemas = options.messageSchemas
-    this.messageSchemaContainer = new MessageSchemaContainer<MessagePayloadType>({
-      messageSchemas,
-      messageTypeField: options.messageTypeField,
-    })
+    this.messageSchemaContainer = this.resolvePublisherMessageSchemaContainer(options)
     this.exchange = options.exchange
   }
 

--- a/packages/core/lib/queues/AbstractQueueService.ts
+++ b/packages/core/lib/queues/AbstractQueueService.ts
@@ -162,14 +162,10 @@ export abstract class AbstractQueueService<
 
   protected handleError(err: unknown, context?: Record<string, unknown>) {
     const logObject = resolveGlobalErrorLogObject(err)
-    if (logObject === 'string') {
-      this.logger.error(context, logObject)
-    } else if (typeof logObject === 'object') {
-      this.logger.error({
-        ...logObject,
-        ...context,
-      })
-    }
+    this.logger.error({
+      ...logObject,
+      ...context,
+    })
     if (types.isNativeError(err)) {
       this.errorReporter.report({ error: err, context })
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run build:release"
   },
   "dependencies": {
-    "@lokalise/node-core": "^9.17.0",
+    "@lokalise/node-core": "^9.21.0",
     "@message-queue-toolkit/schemas": "^1.0.0",
     "fast-equals": "^5.0.1",
     "toad-cache": "^3.7.0",

--- a/packages/schemas/lib/events/eventTypes.ts
+++ b/packages/schemas/lib/events/eventTypes.ts
@@ -8,6 +8,10 @@ import type { CONSUMER_BASE_EVENT_SCHEMA, PUBLISHER_BASE_EVENT_SCHEMA } from './
 export type EventTypeNames<EventDefinition extends CommonEventDefinition> =
   CommonEventDefinitionConsumerSchemaType<EventDefinition>['type']
 
+export function isCommonEventDefinition(entity: unknown): entity is CommonEventDefinition {
+  return (entity as CommonEventDefinition).publisherSchema !== undefined
+}
+
 export type CommonEventDefinition = {
   consumerSchema: ZodObject<
     Omit<(typeof CONSUMER_BASE_EVENT_SCHEMA)['shape'], 'payload'> & { payload: ZodTypeAny }
@@ -16,6 +20,13 @@ export type CommonEventDefinition = {
     Omit<(typeof PUBLISHER_BASE_EVENT_SCHEMA)['shape'], 'payload'> & { payload: ZodTypeAny }
   >
   schemaVersion?: string
+
+  //
+  // Metadata used for automated documentation generation
+  //
+  producedBy?: readonly string[] // Service ids for all the producers of this event.
+  domain?: string // Domain of the event
+  tags?: readonly string[] // Free-form tags for the event
 }
 
 export type CommonEventDefinitionConsumerSchemaType<T extends CommonEventDefinition> = z.infer<

--- a/packages/sns/lib/sns/AbstractSnsPublisher.ts
+++ b/packages/sns/lib/sns/AbstractSnsPublisher.ts
@@ -8,8 +8,8 @@ import type {
   MessageInvalidFormatError,
   MessageValidationError,
   QueuePublisherOptions,
+  MessageSchemaContainer,
 } from '@message-queue-toolkit/core'
-import { MessageSchemaContainer } from '@message-queue-toolkit/core'
 
 import type { SNSCreationConfig, SNSDependencies, SNSQueueLocatorType } from './AbstractSnsService'
 import { AbstractSnsService } from './AbstractSnsService'
@@ -36,11 +36,7 @@ export abstract class AbstractSnsPublisher<MessagePayloadType extends object>
   constructor(dependencies: SNSDependencies, options: SNSPublisherOptions<MessagePayloadType>) {
     super(dependencies, options)
 
-    const messageSchemas = options.messageSchemas
-    this.messageSchemaContainer = new MessageSchemaContainer<MessagePayloadType>({
-      messageSchemas,
-      messageTypeField: options.messageTypeField,
-    })
+    this.messageSchemaContainer = this.resolvePublisherMessageSchemaContainer(options)
   }
 
   async publish(message: MessagePayloadType, options: SNSMessageOptions = {}): Promise<void> {

--- a/packages/sns/test/consumers/handlers/EntityCreatedHandler.ts
+++ b/packages/sns/test/consumers/handlers/EntityCreatedHandler.ts
@@ -1,0 +1,14 @@
+import type { Either } from '@lokalise/node-core'
+import type z from 'zod'
+
+import type { TestEvents } from '../../utils/testContext'
+
+let _latestData: string
+
+export async function entityCreatedHandler(
+  message: z.infer<typeof TestEvents.created.consumerSchema>,
+): Promise<Either<'retryLater', 'success'>> {
+  _latestData = message.payload.newData
+
+  return { result: 'success' }
+}

--- a/packages/sns/test/consumers/handlers/EntityUpdatedHandler.ts
+++ b/packages/sns/test/consumers/handlers/EntityUpdatedHandler.ts
@@ -1,0 +1,14 @@
+import type { Either } from '@lokalise/node-core'
+import type z from 'zod'
+
+import type { TestEvents } from '../../utils/testContext'
+
+let _latestData: string
+
+export async function entityUpdatedHandler(
+  message: z.infer<typeof TestEvents.updated.consumerSchema>,
+): Promise<Either<'retryLater', 'success'>> {
+  _latestData = message.payload.updatedData
+
+  return { result: 'success' }
+}

--- a/packages/sns/test/utils/testContext.ts
+++ b/packages/sns/test/utils/testContext.ts
@@ -54,6 +54,7 @@ export const TestEvents = {
 
 export type TestEventsType = (typeof TestEvents)[keyof typeof TestEvents][]
 export type TestEventPublishPayloadsType = z.infer<TestEventsType[number]['publisherSchema']>
+export type TestEventConsumerPayloadsType = z.infer<TestEventsType[number]['consumerSchema']>
 
 export async function registerDependencies(
   dependencyOverrides: DependencyOverrides = {},

--- a/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
@@ -10,13 +10,9 @@ import type {
   QueueConsumerDependencies,
   DeadLetterQueueOptions,
   ParseMessageResult,
-} from '@message-queue-toolkit/core'
-import {
-  isMessageError,
-  parseMessage,
-  HandlerContainer,
   MessageSchemaContainer,
 } from '@message-queue-toolkit/core'
+import { isMessageError, parseMessage, HandlerContainer } from '@message-queue-toolkit/core'
 import { Consumer } from 'sqs-consumer'
 import type { ConsumerOptions } from 'sqs-consumer/src/types'
 
@@ -115,8 +111,9 @@ export abstract class AbstractSqsConsumer<
 
   protected deadLetterQueueUrl?: string
   protected readonly errorResolver: ErrorResolver
-  protected readonly messageSchemaContainer: MessageSchemaContainer<MessagePayloadType>
   protected readonly executionContext: ExecutionContext
+
+  public readonly messageSchemaContainer: MessageSchemaContainer<MessagePayloadType>
 
   protected constructor(
     dependencies: SQSConsumerDependencies,
@@ -131,11 +128,7 @@ export abstract class AbstractSqsConsumer<
     this.maxRetryDuration = options.maxRetryDuration ?? DEFAULT_MAX_RETRY_DURATION
     this.executionContext = executionContext
 
-    const messageSchemas = options.handlers.map((entry) => entry.schema)
-    this.messageSchemaContainer = new MessageSchemaContainer<MessagePayloadType>({
-      messageSchemas,
-      messageTypeField: options.messageTypeField,
-    })
+    this.messageSchemaContainer = this.resolveConsumerMessageSchemaContainer(options)
     this.handlerContainer = new HandlerContainer<
       MessagePayloadType,
       ExecutionContext,

--- a/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
@@ -8,8 +8,8 @@ import type {
   MessageValidationError,
   BarrierResult,
   QueuePublisherOptions,
+  MessageSchemaContainer,
 } from '@message-queue-toolkit/core'
-import { MessageSchemaContainer } from '@message-queue-toolkit/core'
 import type { ZodSchema } from 'zod'
 
 import type { SQSMessage } from '../types/MessageTypes'
@@ -35,11 +35,7 @@ export abstract class AbstractSqsPublisher<MessagePayloadType extends object>
   ) {
     super(dependencies, options)
 
-    const messageSchemas = options.messageSchemas
-    this.messageSchemaContainer = new MessageSchemaContainer<MessagePayloadType>({
-      messageSchemas,
-      messageTypeField: options.messageTypeField,
-    })
+    this.messageSchemaContainer = this.resolvePublisherMessageSchemaContainer(options)
   }
 
   async publish(message: MessagePayloadType, options: SQSMessageOptions = {}): Promise<void> {


### PR DESCRIPTION
This allows including more metadata on a consumer and publisher level, providing deeper introspection possibilities.

We are planning to use this extra metadata for automated generation of EventCatalog documentation.