### PR TITLE
Relax validation requirements for DomainEventEmitter

### DIFF
--- a/packages/core/lib/events/DomainEventEmitter.spec.ts
+++ b/packages/core/lib/events/DomainEventEmitter.spec.ts
@@ -109,7 +109,14 @@ describe('AutopilotEventEmitter', () => {
     const fakeListener = new FakeListener(diContainer.cradle.eventRegistry.supportedEvents)
     eventEmitter.onAny(fakeListener)
 
-    await eventEmitter.emit(TestEvents.created, createdEventPayload, {
+    const partialCreatedEventPayload = {
+      ...createdEventPayload,
+      metadata: {
+        ...createdEventPayload.metadata,
+        producedBy: undefined,
+      },
+    }
+    await eventEmitter.emit(TestEvents.created, partialCreatedEventPayload, {
       correlationId: 'dummy',
     })
 
@@ -129,7 +136,20 @@ describe('AutopilotEventEmitter', () => {
       type: 'entity.created',
     })
     expect(fakeListener.receivedEvents).toHaveLength(1)
-    expect(fakeListener.receivedEvents[0]).toMatchObject(expectedCreatedPayload)
+    expect(fakeListener.receivedEvents[0]).toMatchObject({
+      id: expect.any(String),
+      metadata: {
+        correlationId: expect.any(String),
+        originatedFrom: 'service',
+        producedBy: undefined,
+        schemaVersion: '1',
+      },
+      payload: {
+        message: 'msg',
+      },
+      timestamp: expect.any(String),
+      type: 'entity.created',
+    })
     expect(fakeListener.receivedMetadata).toHaveLength(1)
     expect(fakeListener.receivedMetadata[0]).toMatchObject({
       correlationId: 'dummy',

--- a/packages/core/lib/events/DomainEventEmitter.ts
+++ b/packages/core/lib/events/DomainEventEmitter.ts
@@ -21,7 +21,7 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
 
   private readonly eventHandlerMap: Record<
     string,
-    EventHandler<CommonEventDefinitionConsumerSchemaType<SupportedEvents[number]>>[]
+    EventHandler<CommonEventDefinitionPublisherSchemaType<SupportedEvents[number]>>[]
   > = {}
   private readonly anyHandlers: AnyEventHandler<SupportedEvents>[] = []
   private readonly metadataFiller: MetadataFiller
@@ -49,7 +49,7 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
   }
 
   get handlerSpy(): PublicHandlerSpy<
-    CommonEventDefinitionConsumerSchemaType<SupportedEvents[number]>
+    CommonEventDefinitionPublisherSchemaType<SupportedEvents[number]>
   > {
     if (!this._handlerSpy) {
       throw new Error(
@@ -90,7 +90,7 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
 
     const validatedEvent = this.eventRegistry
       .getEventDefinitionByTypeName(eventTypeName)
-      .consumerSchema.parse({
+      .publisherSchema.parse({
         type: eventTypeName,
         ...data,
       })

--- a/packages/core/lib/events/fakes/FakeListener.ts
+++ b/packages/core/lib/events/fakes/FakeListener.ts
@@ -1,19 +1,19 @@
-import type { ConsumerMessageMetadataType } from '@message-queue-toolkit/schemas'
+import type { PublisherMessageMetadataType } from '@message-queue-toolkit/schemas'
 import type { AnyEventHandler, CommonEventDefinition } from '../eventTypes'
 
 export class FakeListener<SupportedEvents extends CommonEventDefinition[]>
   implements AnyEventHandler<SupportedEvents>
 {
-  public receivedEvents: SupportedEvents[number]['consumerSchema']['_output'][] = []
-  public receivedMetadata: ConsumerMessageMetadataType[] = []
+  public receivedEvents: SupportedEvents[number]['publisherSchema']['_output'][] = []
+  public receivedMetadata: PublisherMessageMetadataType[] = []
 
   constructor(_supportedEvents: SupportedEvents) {
     this.receivedEvents = []
   }
 
   handleEvent(
-    event: SupportedEvents[number]['consumerSchema']['_output'],
-    metadata: ConsumerMessageMetadataType,
+    event: SupportedEvents[number]['publisherSchema']['_output'],
+    metadata: PublisherMessageMetadataType,
   ): void | Promise<void> {
     this.receivedEvents.push(event)
     this.receivedMetadata.push(metadata)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/core",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "private": false,
   "license": "MIT",
   "description": "Useful utilities, interfaces and base classes for message queue handling. Supports AMQP and SQS with a common abstraction on top currently",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@lokalise/node-core": "^10.0.1",
-    "@message-queue-toolkit/schemas": "^2.0.0",
+    "@message-queue-toolkit/schemas": "^2.1.1",
     "fast-equals": "^5.0.1",
     "json-stream-stringify": "^3.1.4",
     "tmp": "^0.2.3",

--- a/packages/schemas/lib/events/eventTypes.ts
+++ b/packages/schemas/lib/events/eventTypes.ts
@@ -39,7 +39,7 @@ export type CommonEventDefinitionPublisherSchemaType<T extends CommonEventDefini
 
 export type EventHandler<
   EventDefinitionSchema extends
-    CommonEventDefinitionConsumerSchemaType<CommonEventDefinition> = CommonEventDefinitionConsumerSchemaType<CommonEventDefinition>,
+    CommonEventDefinitionPublisherSchemaType<CommonEventDefinition> = CommonEventDefinitionPublisherSchemaType<CommonEventDefinition>,
   MetadataDefinitionSchema extends
     Partial<PublisherMessageMetadataType> = Partial<PublisherMessageMetadataType>,
 > = {
@@ -50,7 +50,7 @@ export type EventHandler<
 }
 
 export type AnyEventHandler<EventDefinitions extends CommonEventDefinition[]> = EventHandler<
-  CommonEventDefinitionConsumerSchemaType<EventDefinitions[number]>
+  CommonEventDefinitionPublisherSchemaType<EventDefinitions[number]>
 >
 
 export type SingleEventHandler<
@@ -62,6 +62,6 @@ type EventFromArrayByTypeName<
   EventDefinition extends CommonEventDefinition[],
   EventTypeName extends EventTypeNames<EventDefinition[number]>,
 > = Extract<
-  CommonEventDefinitionConsumerSchemaType<EventDefinition[number]>,
+  CommonEventDefinitionPublisherSchemaType<EventDefinition[number]>,
   { type: EventTypeName }
 >

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/schemas",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "license": "MIT",
   "description": "Useful utilities, interfaces and base classes for message queue handling. Supports AMQP and SQS with a common abstraction on top currently",


### PR DESCRIPTION
Thi prevents failures due to missing metadata when full-blown messages with metadata are used as events