### PR TITLE
AP-5046 outbox-core package for transactional outbox pattern

### DIFF
--- a/packages/outbox-core/README.md
+++ b/packages/outbox-core/README.md
@@ -35,8 +35,29 @@ const job = new OutboxPeriodicJob(
 
 Job will take care of processing outbox entries emitted by:
 ```typescript
-const emitter = new OutboxEventEmitter(
+import {
+  type CommonEventDefinition,
+  enrichMessageSchemaWithBase,
+} from '@message-queue-toolkit/schemas'
+
+const MyEvents = {
+  created: {
+    ...enrichMessageSchemaWithBase(
+      'entity.created',
+      z.object({
+        message: z.string(),
+      }),
+    ),
+  },
+} as const satisfies Record<string, CommonEventDefinition>
+
+type MySupportedEvents = (typeof TestEvents)[keyof typeof TestEvents][]
+
+const emitter = new OutboxEventEmitter<MySupportedEvents>(
     //Same instance of outbox storage that is used by OutboxPeriodicJob
     outboxStorage
 )
+
+//It pushes the entry to the storage, later will be picked up by the OutboxPeriodicJob
+await emitter.emit(/* args */)
 ```

--- a/packages/outbox-core/README.md
+++ b/packages/outbox-core/README.md
@@ -5,7 +5,7 @@ Main package that contains the core functionality of the Outbox pattern to provi
 ## Installation
 
 ```bash
-npm i -S outbox-core
+npm i -S @message-queue-toolkit/outbox-core
 ```
 
 ## Usage

--- a/packages/outbox-core/README.md
+++ b/packages/outbox-core/README.md
@@ -1,3 +1,42 @@
 # outbox-core
 
-WIP
+Main package that contains the core functionality of the Outbox pattern to provide "at least once" delivery semantics for messages.
+
+## Installation
+
+```bash
+npm i -S outbox-core
+```
+
+## Usage
+
+To process outbox entries and emit them to the message queue, you need to create an instance of the `OutboxPeriodicJob` class:
+
+```typescript
+import { OutboxPeriodicJob } from '@message-queue-toolkit/outbox-core';
+
+const job = new OutboxPeriodicJob(
+    //Implementation of OutboxStorage interface, TODO: Point to other packages in message-queue-toolkit
+    outboxStorage, 
+    //Default available accumulator for gathering outbox entries as the process job is progressing.
+    new InMemoryOutboxAccumulator(), //Default accumulator
+    //DomainEventEmitter, it will be used to publish events, see @message-queue-toolkit/core
+    eventEmitter,
+    //See PeriodicJobDependencies from @lokalise/background-jobs-common
+    dependencies,
+    //Retry count, how many times outbox entries should be retried to be processed
+    3,
+    //emitBatchSize - how many outbox entries should be emitted at once
+    10,
+    //internalInMs - how often the job should be executed, e.g. below it runs every 1sec
+    1000
+)
+```
+
+Job will take care of processing outbox entries emitted by:
+```typescript
+const emitter = new OutboxEventEmitter(
+    //Same instance of outbox storage that is used by OutboxPeriodicJob
+    outboxStorage
+)
+```

--- a/packages/outbox-core/README.md
+++ b/packages/outbox-core/README.md
@@ -19,7 +19,7 @@ const job = new OutboxPeriodicJob(
     //Implementation of OutboxStorage interface, TODO: Point to other packages in message-queue-toolkit
     outboxStorage, 
     //Default available accumulator for gathering outbox entries as the process job is progressing.
-    new InMemoryOutboxAccumulator(), //Default accumulator
+    new InMemoryOutboxAccumulator(),
     //DomainEventEmitter, it will be used to publish events, see @message-queue-toolkit/core
     eventEmitter,
     //See PeriodicJobDependencies from @lokalise/background-jobs-common

--- a/packages/outbox-core/README.md
+++ b/packages/outbox-core/README.md
@@ -1,0 +1,3 @@
+# outbox-core
+
+WIP

--- a/packages/outbox-core/index.ts
+++ b/packages/outbox-core/index.ts
@@ -1,1 +1,4 @@
 export * from './lib/outbox'
+export * from './lib/objects'
+export * from './lib/accumulators'
+export * from './lib/storage'

--- a/packages/outbox-core/index.ts
+++ b/packages/outbox-core/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/outbox'

--- a/packages/outbox-core/lib/accumulators.ts
+++ b/packages/outbox-core/lib/accumulators.ts
@@ -1,15 +1,41 @@
 import type { CommonEventDefinition } from '@message-queue-toolkit/schemas'
 import type { OutboxEntry } from './objects.ts'
 
+/**
+ * Accumulator is responsible for storing outbox entries in two cases:
+ * - successfully dispatched event
+ * - failed events
+ *
+ * Thanks to this, we can use aggregated result and persist in the storage in batches.
+ */
 export interface OutboxAccumulator<SupportedEvents extends CommonEventDefinition[]> {
+  /**
+   * Accumulates successfully dispatched event.
+   * @param outboxEntry
+   */
   add(outboxEntry: OutboxEntry<SupportedEvents[number]>): Promise<void>
 
+  /**
+   * Accumulates failed event.
+   * @param outboxEntry
+   */
   addFailure(outboxEntry: OutboxEntry<SupportedEvents[number]>): Promise<void>
 
+  /**
+   * It's meant to be used by OutboxStorage::flush() to get all entries that should be persisted as successful ones.
+   */
   getEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]>
 
+  /**
+   * Also used by OutboxStorage::flush() to get all entries that should be persisted as failed ones. Such entries will be retried + their retryCount will be incremented.
+   */
   getFailedEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]>
 
+  /**
+   * After running clear(), no entries should be returned by getEntries() and getFailedEntries().
+   *
+   * clear() is always called after flush() in OutboxStorage.
+   */
   clear(): Promise<void>
 }
 

--- a/packages/outbox-core/lib/accumulators.ts
+++ b/packages/outbox-core/lib/accumulators.ts
@@ -22,12 +22,12 @@ export interface OutboxAccumulator<SupportedEvents extends CommonEventDefinition
   addFailure(outboxEntry: OutboxEntry<SupportedEvents[number]>): Promise<void>
 
   /**
-   * It's meant to be used by OutboxStorage::flush() to get all entries that should be persisted as successful ones.
+   * Returns all entries that should be persisted as successful ones.
    */
   getEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]>
 
   /**
-   * Also used by OutboxStorage::flush() to get all entries that should be persisted as failed ones. Such entries will be retried + their retryCount will be incremented.
+   * Returns all entries that should be persisted as failed ones. Such entries will be retried + their retryCount will be incremented.
    */
   getFailedEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]>
 

--- a/packages/outbox-core/lib/accumulators.ts
+++ b/packages/outbox-core/lib/accumulators.ts
@@ -1,0 +1,47 @@
+import type { CommonEventDefinition } from '@message-queue-toolkit/schemas'
+import type { OutboxEntry } from './objects.ts'
+
+export interface OutboxAccumulator<SupportedEvents extends CommonEventDefinition[]> {
+  add(outboxEntry: OutboxEntry<SupportedEvents[number]>): Promise<void>
+
+  addFailure(outboxEntry: OutboxEntry<SupportedEvents[number]>): Promise<void>
+
+  getEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]>
+
+  getFailedEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]>
+
+  clear(): Promise<void>
+}
+
+export class InMemoryOutboxAccumulator<SupportedEvents extends CommonEventDefinition[]>
+  implements OutboxAccumulator<SupportedEvents>
+{
+  private entries: OutboxEntry<SupportedEvents[number]>[] = []
+  private failedEntries: OutboxEntry<SupportedEvents[number]>[] = []
+
+  public add(outboxEntry: OutboxEntry<SupportedEvents[number]>) {
+    this.entries = [...this.entries, outboxEntry]
+
+    return Promise.resolve()
+  }
+
+  public addFailure(outboxEntry: OutboxEntry<SupportedEvents[number]>) {
+    this.failedEntries = [...this.failedEntries, outboxEntry]
+
+    return Promise.resolve()
+  }
+
+  getEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]> {
+    return Promise.resolve(this.entries)
+  }
+
+  getFailedEntries(): Promise<OutboxEntry<SupportedEvents[number]>[]> {
+    return Promise.resolve(this.failedEntries)
+  }
+
+  public clear(): Promise<void> {
+    this.entries = []
+    this.failedEntries = []
+    return Promise.resolve()
+  }
+}

--- a/packages/outbox-core/lib/accumulators.ts
+++ b/packages/outbox-core/lib/accumulators.ts
@@ -46,13 +46,13 @@ export class InMemoryOutboxAccumulator<SupportedEvents extends CommonEventDefini
   private failedEntries: OutboxEntry<SupportedEvents[number]>[] = []
 
   public add(outboxEntry: OutboxEntry<SupportedEvents[number]>) {
-    this.entries = [...this.entries, outboxEntry]
+    this.entries.push(outboxEntry)
 
     return Promise.resolve()
   }
 
   public addFailure(outboxEntry: OutboxEntry<SupportedEvents[number]>) {
-    this.failedEntries = [...this.failedEntries, outboxEntry]
+    this.failedEntries.push(outboxEntry)
 
     return Promise.resolve()
   }

--- a/packages/outbox-core/lib/objects.ts
+++ b/packages/outbox-core/lib/objects.ts
@@ -1,0 +1,25 @@
+import type {
+  CommonEventDefinition,
+  CommonEventDefinitionPublisherSchemaType,
+  ConsumerMessageMetadataType,
+} from '@message-queue-toolkit/schemas'
+
+/**
+ * Status of the outbox entry.
+ * - CREATED - entry was created and is waiting to be processed to publish actual event
+ * - ACKED - entry was picked up by outbox job and is being processed
+ * - SUCCESS - entry was successfully processed, event was published
+ * - FAILED - entry processing failed, it will be retried
+ */
+export type OutboxEntryStatus = 'CREATED' | 'ACKED' | 'SUCCESS' | 'FAILED'
+
+export type OutboxEntry<SupportedEvent extends CommonEventDefinition> = {
+  id: string
+  event: SupportedEvent
+  data: Omit<CommonEventDefinitionPublisherSchemaType<SupportedEvent>, 'type'>
+  precedingMessageMetadata?: Partial<ConsumerMessageMetadataType>
+  status: OutboxEntryStatus
+  created: Date
+  updated?: Date
+  retryCount: number
+}

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -49,31 +49,6 @@ const createdEventPayload: CommonEventDefinitionPublisherSchemaType<typeof TestE
   },
 }
 
-const updatedEventPayload: CommonEventDefinitionPublisherSchemaType<typeof TestEvents.updated> = {
-  ...createdEventPayload,
-  type: 'entity.updated',
-}
-
-const expectedCreatedPayload = {
-  id: expect.any(String),
-  timestamp: expect.any(String),
-  payload: {
-    message: 'msg',
-  },
-  type: 'entity.created',
-  metadata: {
-    correlationId: expect.any(String),
-    originatedFrom: 'service',
-    producedBy: 'producer',
-    schemaVersion: '1',
-  },
-}
-
-const expectedUpdatedPayload = {
-  ...expectedCreatedPayload,
-  type: 'entity.updated',
-}
-
 const TestLogger: Logger = pino()
 
 class InMemoryOutboxStorage<SupportedEvents extends CommonEventDefinition[]>

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -151,8 +151,7 @@ describe('outbox', () => {
         outboxAccumulator: new InMemoryOutboxAccumulator(),
         eventEmitter,
       } satisfies OutboxDependencies<TestEventsType>,
-      MAX_RETRY_COUNT,
-      1,
+      { maxRetryCount: MAX_RETRY_COUNT, emitBatchSize: 1 },
     )
   })
 

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { InMemoryOutboxAccumulator, type OutboxAccumulator } from './accumulators'
 import type { OutboxEntry } from './objects'
-import { OutboxEventEmitter, OutboxProcessor } from './outbox'
+import { type OutboxDependencies, OutboxEventEmitter, OutboxProcessor } from './outbox'
 import type { OutboxStorage } from './storage'
 
 const TestEvents = {
@@ -145,10 +145,12 @@ describe('outbox', () => {
     outboxStorage = new InMemoryOutboxStorage<TestEventsType>()
     outboxEventEmitter = new OutboxEventEmitter<TestEventsType>(outboxStorage)
     outboxProcessor = new OutboxProcessor<TestEventsType>(
-      outboxStorage,
-      //@ts-ignore
-      new InMemoryOutboxAccumulator(),
-      eventEmitter,
+      {
+        outboxStorage,
+        //@ts-ignore
+        outboxAccumulator: new InMemoryOutboxAccumulator(),
+        eventEmitter,
+      } satisfies OutboxDependencies<TestEventsType>,
       MAX_RETRY_COUNT,
       1,
     )

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -1,0 +1,32 @@
+import {
+  type SnsAwareEventDefinition,
+  enrichEventSchemaWithBase,
+} from '@message-queue-toolkit/schemas'
+import { describe } from 'vitest'
+import { z } from 'zod'
+import type { OutboxStorage } from './outbox'
+
+const TEST_EVENT_SCHEMA = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const testEvents = {
+  'test-event.something-happened': {
+    ...enrichEventSchemaWithBase('test-event.something-happened', TEST_EVENT_SCHEMA),
+    snsTopic: 'TEST_TOPIC',
+    producedBy: ['unit tes'],
+  },
+} satisfies Record<string, SnsAwareEventDefinition>
+
+console.log(testEvents)
+
+const testEventsArray = [...Object.values(testEvents)] satisfies SnsAwareEventDefinition[]
+
+type TestEvents = typeof testEventsArray
+
+class InMemoryOutbox implements OutboxStorage<TestEvents> {}
+
+describe('outbox', () => {
+  it('saves outbox entry to process it later', async () => {})
+})

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -1,32 +1,170 @@
+import { randomUUID } from 'node:crypto'
 import {
-  type SnsAwareEventDefinition,
-  enrichEventSchemaWithBase,
+  CommonMetadataFiller,
+  DomainEventEmitter,
+  EventRegistry,
+} from '@message-queue-toolkit/core'
+import {
+  type CommonEventDefinition,
+  type CommonEventDefinitionPublisherSchemaType,
+  enrichMessageSchemaWithBase,
 } from '@message-queue-toolkit/schemas'
-import { describe } from 'vitest'
+import pino, { type Logger } from 'pino'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
-import type { OutboxStorage } from './outbox'
+import { type OutboxEntry, OutboxEventEmitter, OutboxProcessor, type OutboxStorage } from './outbox'
 
-const TEST_EVENT_SCHEMA = z.object({
-  name: z.string(),
-  age: z.number(),
-})
-
-const testEvents = {
-  'test-event.something-happened': {
-    ...enrichEventSchemaWithBase('test-event.something-happened', TEST_EVENT_SCHEMA),
-    snsTopic: 'TEST_TOPIC',
-    producedBy: ['unit tes'],
+const TestEvents = {
+  created: {
+    ...enrichMessageSchemaWithBase(
+      'entity.created',
+      z.object({
+        message: z.string(),
+      }),
+    ),
   },
-} satisfies Record<string, SnsAwareEventDefinition>
 
-console.log(testEvents)
+  updated: {
+    ...enrichMessageSchemaWithBase(
+      'entity.updated',
+      z.object({
+        message: z.string(),
+      }),
+    ),
+  },
+} as const satisfies Record<string, CommonEventDefinition>
 
-const testEventsArray = [...Object.values(testEvents)] satisfies SnsAwareEventDefinition[]
+type TestEventsType = (typeof TestEvents)[keyof typeof TestEvents][]
 
-type TestEvents = typeof testEventsArray
+const createdEventPayload: CommonEventDefinitionPublisherSchemaType<typeof TestEvents.created> = {
+  payload: {
+    message: 'msg',
+  },
+  type: 'entity.created',
+  metadata: {
+    originatedFrom: 'service',
+    producedBy: 'producer',
+    schemaVersion: '1',
+    correlationId: randomUUID(),
+  },
+}
 
-class InMemoryOutbox implements OutboxStorage<TestEvents> {}
+const updatedEventPayload: CommonEventDefinitionPublisherSchemaType<typeof TestEvents.updated> = {
+  ...createdEventPayload,
+  type: 'entity.updated',
+}
+
+const expectedCreatedPayload = {
+  id: expect.any(String),
+  timestamp: expect.any(String),
+  payload: {
+    message: 'msg',
+  },
+  type: 'entity.created',
+  metadata: {
+    correlationId: expect.any(String),
+    originatedFrom: 'service',
+    producedBy: 'producer',
+    schemaVersion: '1',
+  },
+}
+
+const expectedUpdatedPayload = {
+  ...expectedCreatedPayload,
+  type: 'entity.updated',
+}
+
+const TestLogger: Logger = pino()
+
+class InMemoryOutboxStorage<SupportedEvents extends CommonEventDefinition[]>
+  implements OutboxStorage<SupportedEvents>
+{
+  public entries: OutboxEntry<SupportedEvents[number]>[] = []
+
+  create(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>> {
+    this.entries = [...this.entries, outboxEntry]
+
+    return Promise.resolve(outboxEntry)
+  }
+
+  getEntries(maxRetryCount: number): Promise<OutboxEntry<SupportedEvents[number]>[]> {
+    const entries = this.entries.filter((entry) => {
+      return entry.status !== 'SUCCESS' && entry.retryCount <= maxRetryCount
+    })
+
+    return Promise.resolve(entries)
+  }
+
+  update(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>> {
+    this.entries = this.entries.map((entry) => {
+      if (entry.id === outboxEntry.id) {
+        return outboxEntry
+      }
+      return entry
+    })
+
+    return Promise.resolve(outboxEntry)
+  }
+}
 
 describe('outbox', () => {
-  it('saves outbox entry to process it later', async () => {})
+  let outboxProcessor: OutboxProcessor<TestEventsType>
+  let eventEmitter: DomainEventEmitter<TestEventsType>
+  let outboxEventEmitter: OutboxEventEmitter<TestEventsType>
+  let outboxStorage: InMemoryOutboxStorage<TestEventsType>
+
+  beforeEach(() => {
+    eventEmitter = new DomainEventEmitter({
+      logger: TestLogger,
+      errorReporter: { report: () => {} },
+      eventRegistry: new EventRegistry(Object.values(TestEvents)),
+      metadataFiller: new CommonMetadataFiller({
+        serviceId: 'test',
+      }),
+    })
+
+    outboxStorage = new InMemoryOutboxStorage<TestEventsType>()
+    outboxEventEmitter = new OutboxEventEmitter<TestEventsType>(outboxStorage)
+    outboxProcessor = new OutboxProcessor<TestEventsType>(outboxStorage, eventEmitter, 2)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('saves outbox entry to storage', async () => {
+    await outboxEventEmitter.emit(TestEvents.created, createdEventPayload, {
+      correlationId: randomUUID(),
+    })
+
+    const entries = await outboxStorage.getEntries(2)
+
+    expect(entries).toHaveLength(1)
+  })
+
+  it('saves outbox entry and process it', async () => {
+    await outboxEventEmitter.emit(TestEvents.created, createdEventPayload, {
+      correlationId: randomUUID(),
+    })
+
+    await outboxProcessor.processOutboxEntries({
+      logger: TestLogger,
+      reqId: randomUUID(),
+      executorId: randomUUID(),
+    })
+
+    const entries = await outboxStorage.getEntries(2)
+
+    expect(entries).toHaveLength(0)
+
+    expect(outboxStorage.entries).toMatchObject([
+      {
+        status: 'SUCCESS',
+      },
+    ])
+  })
 })

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -59,7 +59,7 @@ class InMemoryOutboxStorage<SupportedEvents extends CommonEventDefinition[]>
 {
   public entries: OutboxEntry<SupportedEvents[number]>[] = []
 
-  create(
+  createEntry(
     outboxEntry: OutboxEntry<SupportedEvents[number]>,
   ): Promise<OutboxEntry<SupportedEvents[number]>> {
     this.entries = [...this.entries, outboxEntry]

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -12,14 +12,9 @@ import {
 import pino, { type Logger } from 'pino'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
-import {
-  InMemoryOutboxAccumulator,
-  type OutboxAccumulator,
-  type OutboxEntry,
-  OutboxEventEmitter,
-  OutboxProcessor,
-  type OutboxStorage,
-} from './outbox'
+import { InMemoryOutboxAccumulator, type OutboxAccumulator } from './accumulators'
+import type { OutboxEntry } from './objects'
+import { OutboxEventEmitter, OutboxProcessor, type OutboxStorage } from './outbox'
 
 const TestEvents = {
   created: {
@@ -125,8 +120,6 @@ class InMemoryOutboxStorage<SupportedEvents extends CommonEventDefinition[]>
       }
       return entry
     })
-
-    outboxAccumulator.clear()
   }
 }
 

--- a/packages/outbox-core/lib/outbox.spec.ts
+++ b/packages/outbox-core/lib/outbox.spec.ts
@@ -14,7 +14,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { InMemoryOutboxAccumulator, type OutboxAccumulator } from './accumulators'
 import type { OutboxEntry } from './objects'
-import { OutboxEventEmitter, OutboxProcessor, type OutboxStorage } from './outbox'
+import { OutboxEventEmitter, OutboxProcessor } from './outbox'
+import type { OutboxStorage } from './storage'
 
 const TestEvents = {
   created: {

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -126,7 +126,7 @@ export class OutboxEventEmitter<SupportedEvents extends CommonEventDefinition[]>
     data: Omit<CommonEventDefinitionPublisherSchemaType<SupportedEvent>, 'type'>,
     precedingMessageMetadata?: Partial<ConsumerMessageMetadataType>,
   ) {
-    await this.storage.create({
+    await this.storage.createEntry({
       id: uuidv7(),
       event: supportedEvent,
       data,

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -1,5 +1,5 @@
 import { AbstractPeriodicJob, type JobExecutionContext } from '@lokalise/background-jobs-common'
-import type { PeriodicJobDependencies } from '@lokalise/background-jobs-common/dist/periodic-jobs/periodicJobTypes'
+import type { PeriodicJobDependencies } from '@lokalise/background-jobs-common'
 import { generateUuid7 } from '@lokalise/id-utils'
 import type {
   CommonEventDefinition,

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -1,0 +1,9 @@
+export interface OutboxStorage {
+    saveMessage(message: unknown): Promise<void>
+    getMessage(): Promise<unknown>
+    deleteMessage(): Promise<void>
+}
+
+export class OutboxProcessor {
+
+}

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -95,7 +95,7 @@ export class OutboxProcessor<SupportedEvents extends CommonEventDefinition[]> {
 }
 
 /**
- * Periodic job that processes outbox entries every second. If processing takes longer than 1 second, another subsequent job WILL NOT be started.
+ * Periodic job that processes outbox entries every "intervalInMs". If processing takes longer than defined interval, another subsequent job WILL NOT be started.
  *
  * Each entry is ACKed, then event is published, and then entry is marked as SUCCESS. If processing fails, entry is marked as FAILED and will be retried.
  *
@@ -109,14 +109,15 @@ export class OutboxPeriodicJob<
   constructor(
     outboxStorage: OutboxStorage<SupportedEvents>,
     eventEmitter: DomainEventEmitter<SupportedEvents>,
-    maxRetryCount: number,
     dependencies: PeriodicJobDependencies,
+    maxRetryCount: number,
+    intervalInMs: number,
   ) {
     super(
       {
         jobId: 'OutboxJob',
         schedule: {
-          intervalInMs: 1000,
+          intervalInMs: intervalInMs,
         },
         singleConsumerMode: {
           enabled: true,

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -1,12 +1,12 @@
 import { AbstractPeriodicJob, type JobExecutionContext } from '@lokalise/background-jobs-common'
 import type { PeriodicJobDependencies } from '@lokalise/background-jobs-common'
-import { generateUuid7 } from '@lokalise/id-utils'
 import type {
   CommonEventDefinition,
   CommonEventDefinitionPublisherSchemaType,
   ConsumerMessageMetadataType,
   DomainEventEmitter,
 } from '@message-queue-toolkit/core'
+import { uuidv7 } from 'uuidv7'
 
 /**
  * Status of the outbox entry.
@@ -158,7 +158,7 @@ export class OutboxEventEmitter<SupportedEvents extends CommonEventDefinition[]>
     precedingMessageMetadata?: Partial<ConsumerMessageMetadataType>,
   ) {
     await this.storage.create({
-      id: generateUuid7(),
+      id: uuidv7(),
       event: supportedEvent,
       data,
       precedingMessageMetadata,

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -26,6 +26,7 @@ export type OutboxEntry<SupportedEvent extends CommonEventDefinition> = {
   created: Date
   updated?: Date
   retryCount: number
+  lockedUntil?: Date
 }
 
 /**
@@ -53,6 +54,11 @@ export interface OutboxStorage<SupportedEvents extends CommonEventDefinition[]> 
   getEntries(maxRetryCount: number): Promise<OutboxEntry<SupportedEvents[number]>[]>
 }
 
+/**
+ * Main logic for handling outbox entries.
+ *
+ * If entry is rejected, it is NOT going to be handled during the same execution. Next execution will pick it up.
+ */
 export class OutboxProcessor<SupportedEvents extends CommonEventDefinition[]> {
   constructor(
     private readonly outboxStorage: OutboxStorage<SupportedEvents>,

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -81,6 +81,7 @@ export class OutboxProcessor<SupportedEvents extends CommonEventDefinition[]> {
  *
  * Max retry count is defined by the user.
  */
+/* c8 ignore start */
 export class OutboxPeriodicJob<
   SupportedEvents extends CommonEventDefinition[],
 > extends AbstractPeriodicJob {
@@ -120,6 +121,7 @@ export class OutboxPeriodicJob<
     await this.outboxProcessor.processOutboxEntries(context)
   }
 }
+/* c8 ignore stop */
 
 export class OutboxEventEmitter<SupportedEvents extends CommonEventDefinition[]> {
   constructor(private storage: OutboxStorage<SupportedEvents>) {}

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -1,9 +1,144 @@
-export interface OutboxStorage {
-    saveMessage(message: unknown): Promise<void>
-    getMessage(): Promise<unknown>
-    deleteMessage(): Promise<void>
+import { AbstractPeriodicJob, type JobExecutionContext } from '@lokalise/background-jobs-common'
+import type { PeriodicJobDependencies } from '@lokalise/background-jobs-common/dist/periodic-jobs/periodicJobTypes'
+import { generateUuid7 } from '@lokalise/id-utils'
+import type {
+  CommonEventDefinition,
+  CommonEventDefinitionPublisherSchemaType,
+  ConsumerMessageMetadataType,
+  DomainEventEmitter,
+} from '@message-queue-toolkit/core'
+
+/**
+ * Status of the outbox entry.
+ * - CREATED - entry was created and is waiting to be processed to publish actual event
+ * - ACKED - entry was picked up by outbox job and is being processed
+ * - SUCCESS - entry was successfully processed, event was published
+ * - FAILED - entry processing failed, it will be retried
+ */
+export type OutboxEntryStatus = 'CREATED' | 'ACKED' | 'SUCCESS' | 'FAILED'
+
+export type OutboxEntry<SupportedEvent extends CommonEventDefinition> = {
+  id: string
+  event: SupportedEvent
+  data: Omit<CommonEventDefinitionPublisherSchemaType<SupportedEvent>, 'type'>
+  precedingMessageMetadata?: Partial<ConsumerMessageMetadataType>
+  status: OutboxEntryStatus
+  created: Date
+  updated?: Date
+  retryCount: number
 }
 
-export class OutboxProcessor {
+/**
+ * Takes care of persisting and retrieving outbox entries.
+ *
+ * Implementation is required:
+ * - in order to fulfill at least once delivery guarantee, persisting entries should be performed inside isolated transaction
+ * - to return entries in the order they were created (UUID7 is used to create entries in OutboxEventEmitter)
+ * - returned entries should not include the ones with 'SUCCESS' status
+ */
+export interface OutboxStorage<SupportedEvents extends CommonEventDefinition[]> {
+  create(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>>
 
+  update(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>>
+
+  /**
+   * Returns entries in the order they were created. It doesn't return entries with 'SUCCESS' status. It doesn't return entries that have been retried more than maxRetryCount times.
+   *
+   * For example if entry retryCount is 1 and maxRetryCount is 1, entry MUST be returned. If it fails again then retry count is 2, in that case entry MUST NOT be returned.
+   */
+  getEntries(maxRetryCount: number): Promise<OutboxEntry<SupportedEvents[number]>[]>
+}
+
+/**
+ * Periodic job that processes outbox entries every second. If processing takes longer than 1 second, another subsequent job WILL NOT be started.
+ *
+ * Each entry is ACKed, then event is published, and then entry is marked as SUCCESS. If processing fails, entry is marked as FAILED and will be retried.
+ *
+ * Max retry count is defined by the user.
+ */
+export class OutboxPeriodicJob<
+  SupportedEvents extends CommonEventDefinition[],
+> extends AbstractPeriodicJob {
+  constructor(
+    private readonly outboxStorage: OutboxStorage<SupportedEvents>,
+    private readonly eventEmitter: DomainEventEmitter<SupportedEvents>,
+    private readonly maxRetryCount: number,
+    dependencies: PeriodicJobDependencies,
+  ) {
+    super(
+      {
+        jobId: 'OutboxJob',
+        schedule: {
+          intervalInMs: 1000,
+        },
+        singleConsumerMode: {
+          enabled: true,
+        },
+      },
+      {
+        redis: dependencies.redis,
+        logger: dependencies.logger,
+        transactionObservabilityManager: dependencies.transactionObservabilityManager,
+        errorReporter: dependencies.errorReporter,
+        scheduler: dependencies.scheduler,
+      },
+    )
+  }
+
+  protected async processInternal(context: JobExecutionContext): Promise<void> {
+    const entries = await this.outboxStorage.getEntries(this.maxRetryCount)
+
+    for (const entry of entries) {
+      try {
+        const updatedEntry = await this.outboxStorage.update({
+          ...entry,
+          updated: new Date(),
+          status: 'ACKED',
+        })
+
+        await this.eventEmitter.emit(entry.event, entry.data, entry.precedingMessageMetadata)
+
+        await this.outboxStorage.update({ ...updatedEntry, updated: new Date(), status: 'SUCCESS' })
+      } catch (e) {
+        context.logger.error({ error: e }, 'Failed to process outbox entry.')
+
+        await this.outboxStorage.update({
+          ...entry,
+          updated: new Date(),
+          status: 'FAILED',
+          retryCount: entry.retryCount + 1,
+        })
+      }
+    }
+  }
+}
+
+export class OutboxEventEmitter<SupportedEvents extends CommonEventDefinition[]> {
+  constructor(private storage: OutboxStorage<SupportedEvents>) {}
+
+  /**
+   * Persists outbox entry in persistence layer, later it will be picked up by outbox job.
+   * @param supportedEvent
+   * @param data
+   * @param precedingMessageMetadata
+   */
+  public async emit<SupportedEvent extends SupportedEvents[number]>(
+    supportedEvent: SupportedEvent,
+    data: Omit<CommonEventDefinitionPublisherSchemaType<SupportedEvent>, 'type'>,
+    precedingMessageMetadata?: Partial<ConsumerMessageMetadataType>,
+  ) {
+    await this.storage.create({
+      id: generateUuid7(),
+      event: supportedEvent,
+      data,
+      precedingMessageMetadata,
+      status: 'CREATED',
+      created: new Date(),
+      retryCount: 0,
+    })
+  }
 }

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -49,7 +49,7 @@ export class OutboxProcessor<SupportedEvents extends CommonEventDefinition[]> {
 /**
  * Periodic job that processes outbox entries every "intervalInMs". If processing takes longer than defined interval, another subsequent job WILL NOT be started.
  *
- * Each entry is ACKed, then event is published, and then entry is marked as SUCCESS. If processing fails, entry is marked as FAILED and will be retried.
+ * When event is published, and then entry is accumulated into SUCCESS group. If processing fails, entry is accumulated as FAILED and will be retried.
  *
  * Max retry count is defined by the user.
  */

--- a/packages/outbox-core/lib/outbox.ts
+++ b/packages/outbox-core/lib/outbox.ts
@@ -26,7 +26,6 @@ export type OutboxEntry<SupportedEvent extends CommonEventDefinition> = {
   created: Date
   updated?: Date
   retryCount: number
-  lockedUntil?: Date
 }
 
 /**

--- a/packages/outbox-core/lib/storage.ts
+++ b/packages/outbox-core/lib/storage.ts
@@ -11,7 +11,7 @@ import type { OutboxEntry } from './objects'
  * - returned entries should not include the ones with 'SUCCESS' status
  */
 export interface OutboxStorage<SupportedEvents extends CommonEventDefinition[]> {
-  create(
+  createEntry(
     outboxEntry: OutboxEntry<SupportedEvents[number]>,
   ): Promise<OutboxEntry<SupportedEvents[number]>>
 

--- a/packages/outbox-core/lib/storage.ts
+++ b/packages/outbox-core/lib/storage.ts
@@ -1,0 +1,30 @@
+import type { CommonEventDefinition } from '@message-queue-toolkit/schemas'
+import type { OutboxAccumulator } from './accumulators'
+import type { OutboxEntry } from './objects'
+
+/**
+ * Takes care of persisting and retrieving outbox entries.
+ *
+ * Implementation is required:
+ * - in order to fulfill at least once delivery guarantee, persisting entries should be performed inside isolated transaction
+ * - to return entries in the order they were created (UUID7 is used to create entries in OutboxEventEmitter)
+ * - returned entries should not include the ones with 'SUCCESS' status
+ */
+export interface OutboxStorage<SupportedEvents extends CommonEventDefinition[]> {
+  create(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>>
+
+  flush(outboxAccumulator: OutboxAccumulator<SupportedEvents>): Promise<void>
+
+  update(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>>
+
+  /**
+   * Returns entries in the order they were created. It doesn't return entries with 'SUCCESS' status. It doesn't return entries that have been retried more than maxRetryCount times.
+   *
+   * For example if entry retryCount is 1 and maxRetryCount is 1, entry MUST be returned. If it fails again then retry count is 2, in that case entry MUST NOT be returned.
+   */
+  getEntries(maxRetryCount: number): Promise<OutboxEntry<SupportedEvents[number]>[]>
+}

--- a/packages/outbox-core/lib/storage.ts
+++ b/packages/outbox-core/lib/storage.ts
@@ -17,10 +17,6 @@ export interface OutboxStorage<SupportedEvents extends CommonEventDefinition[]> 
 
   flush(outboxAccumulator: OutboxAccumulator<SupportedEvents>): Promise<void>
 
-  update(
-    outboxEntry: OutboxEntry<SupportedEvents[number]>,
-  ): Promise<OutboxEntry<SupportedEvents[number]>>
-
   /**
    * Returns entries in the order they were created. It doesn't return entries with 'SUCCESS' status. It doesn't return entries that have been retried more than maxRetryCount times.
    *

--- a/packages/outbox-core/lib/storage.ts
+++ b/packages/outbox-core/lib/storage.ts
@@ -15,6 +15,12 @@ export interface OutboxStorage<SupportedEvents extends CommonEventDefinition[]> 
     outboxEntry: OutboxEntry<SupportedEvents[number]>,
   ): Promise<OutboxEntry<SupportedEvents[number]>>
 
+  /**
+   * Responsible for taking all entries from the accumulator and persisting them in the storage.
+   *
+   * - Items that are in OutboxAccumulator::getEntries MUST be changed to SUCCESS status and `updatedAt` field needs to be set.
+   * - Items that are in OutboxAccumulator::getFailedEntries MUST be changed to FAILED status, `updatedAt` field needs to be set and retryCount needs to be incremented.
+   */
   flush(outboxAccumulator: OutboxAccumulator<SupportedEvents>): Promise<void>
 
   /**

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -25,15 +25,16 @@
     "prepublishOnly": "npm run build:release"
   },
   "dependencies": {
-    "@lokalise/background-jobs-common": "^7.6.1"
+    "@lokalise/background-jobs-common": "^7.6.1",
+    "@lokalise/id-utils": "^2.2.0"
   },
   "peerDependencies": {
     "@message-queue-toolkit/core": ">=14.0.0"
   },
   "devDependencies": {
-    "@message-queue-toolkit/core": "*",
     "@biomejs/biome": "1.8.3",
     "@kibertoad/biome-config": "^1.2.1",
+    "@message-queue-toolkit/core": "*",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.0.4",
     "del-cli": "^5.1.0",

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -17,11 +17,9 @@
     "build:release": "del-cli dist && del-cli coverage && npm run lint && tsc --project tsconfig.release.json",
     "test": "vitest",
     "test:coverage": "npm test -- --coverage",
-    "test:ci": "npm run docker:start:dev && npm run test:coverage && npm run docker:stop:dev",
+    "test:ci": "npm run test:coverage",
     "lint": "biome check . && tsc --project tsconfig.json --noEmit",
     "lint:fix": "biome check --write .",
-    "docker:start:dev": "docker compose up -d",
-    "docker:stop:dev": "docker compose down",
     "prepublishOnly": "npm run build:release"
   },
   "dependencies": {

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -55,9 +55,8 @@
     "common",
     "utils",
     "notification",
-    "s3",
-    "store",
-    "claim-check"
+    "outbox",
+    "pattern"
   ],
   "files": ["README.md", "LICENSE", "dist/*"]
 }

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@message-queue-toolkit/outbox-core",
+  "version": "0.1.0",
+  "private": false,
+  "license": "MIT",
+  "description": "Outbox pattern implementation for message queue toolkit",
+  "maintainers": [
+    {
+      "name": "Igor Savin",
+      "email": "kibertoad@gmail.com"
+    }
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "del-cli dist && tsc",
+    "build:release": "del-cli dist && del-cli coverage && npm run lint && tsc --project tsconfig.release.json",
+    "test": "vitest",
+    "test:coverage": "npm test -- --coverage",
+    "test:ci": "npm run docker:start:dev && npm run test:coverage && npm run docker:stop:dev",
+    "lint": "biome check . && tsc --project tsconfig.json --noEmit",
+    "lint:fix": "biome check --write .",
+    "docker:start:dev": "docker compose up -d",
+    "docker:stop:dev": "docker compose down",
+    "prepublishOnly": "npm run build:release"
+  },
+  "dependencies": {
+    "@lokalise/background-jobs-common": "^7.6.1"
+  },
+  "peerDependencies": {
+    "@message-queue-toolkit/core": ">=14.0.0"
+  },
+  "devDependencies": {
+    "@message-queue-toolkit/core": "*",
+    "@biomejs/biome": "1.8.3",
+    "@kibertoad/biome-config": "^1.2.1",
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^2.0.4",
+    "del-cli": "^5.1.0",
+    "typescript": "^5.5.3",
+    "vitest": "^2.0.4"
+  },
+  "homepage": "https://github.com/kibertoad/message-queue-toolkit",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/kibertoad/message-queue-toolkit.git"
+  },
+  "keywords": [
+    "message",
+    "queue",
+    "queues",
+    "abstract",
+    "common",
+    "utils",
+    "notification",
+    "s3",
+    "store",
+    "claim-check"
+  ],
+  "files": ["README.md", "LICENSE", "dist/*"]
+}

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@lokalise/background-jobs-common": "^7.6.1",
+    "@supercharge/promise-pool": "^3.2.0",
     "uuidv7": "^1.0.2"
   },
   "peerDependencies": {

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -29,17 +29,18 @@
     "@lokalise/id-utils": "^2.2.0"
   },
   "peerDependencies": {
-    "@message-queue-toolkit/core": ">=14.0.0"
+    "@message-queue-toolkit/core": ">=14.0.0",
+    "@message-queue-toolkit/schemas": ">=4.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
     "@kibertoad/biome-config": "^1.2.1",
-    "@message-queue-toolkit/core": "*",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.0.4",
     "del-cli": "^5.1.0",
     "typescript": "^5.5.3",
-    "vitest": "^2.0.4"
+    "vitest": "^2.0.4",
+    "zod": "^3.23.8"
   },
   "homepage": "https://github.com/kibertoad/message-queue-toolkit",
   "repository": {

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@lokalise/background-jobs-common": "^7.6.1",
-    "@lokalise/id-utils": "^2.2.0"
+    "uuidv7": "^1.0.2"
   },
   "peerDependencies": {
     "@message-queue-toolkit/core": ">=14.0.0",

--- a/packages/outbox-core/test/InMemoryOutboxStorage.ts
+++ b/packages/outbox-core/test/InMemoryOutboxStorage.ts
@@ -1,0 +1,74 @@
+import type { CommonEventDefinition } from '@message-queue-toolkit/schemas'
+import type { OutboxAccumulator } from '../lib/accumulators'
+import type { OutboxEntry } from '../lib/objects'
+import type { OutboxStorage } from '../lib/storage'
+
+export class InMemoryOutboxStorage<SupportedEvents extends CommonEventDefinition[]>
+  implements OutboxStorage<SupportedEvents>
+{
+  public entries: OutboxEntry<SupportedEvents[number]>[] = []
+
+  createEntry(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>> {
+    this.entries = [...this.entries, outboxEntry]
+
+    return Promise.resolve(outboxEntry)
+  }
+
+  getEntries(maxRetryCount: number): Promise<OutboxEntry<SupportedEvents[number]>[]> {
+    const entries = this.entries.filter((entry) => {
+      return entry.status !== 'SUCCESS' && entry.retryCount <= maxRetryCount
+    })
+
+    return Promise.resolve(entries)
+  }
+
+  update(
+    outboxEntry: OutboxEntry<SupportedEvents[number]>,
+  ): Promise<OutboxEntry<SupportedEvents[number]>> {
+    this.entries = this.entries.map((entry) => {
+      if (entry.id === outboxEntry.id) {
+        return outboxEntry
+      }
+      return entry
+    })
+
+    return Promise.resolve(outboxEntry)
+  }
+
+  public async flush(outboxAccumulator: OutboxAccumulator<SupportedEvents>): Promise<void> {
+    let successEntries = await outboxAccumulator.getEntries()
+    successEntries = successEntries.map((entry) => {
+      return {
+        ...entry,
+        status: 'SUCCESS',
+        updateAt: new Date(),
+      }
+    })
+    this.entries = this.entries.map((entry) => {
+      const foundEntry = successEntries.find((successEntry) => successEntry.id === entry.id)
+      if (foundEntry) {
+        return foundEntry
+      }
+      return entry
+    })
+
+    let failedEntries = await outboxAccumulator.getFailedEntries()
+    failedEntries = failedEntries.map((entry) => {
+      return {
+        ...entry,
+        status: 'FAILED',
+        updateAt: new Date(),
+        retryCount: entry.retryCount + 1,
+      }
+    })
+    this.entries = this.entries.map((entry) => {
+      const foundEntry = failedEntries.find((failedEntry) => failedEntry.id === entry.id)
+      if (foundEntry) {
+        return foundEntry
+      }
+      return entry
+    })
+  }
+}

--- a/packages/outbox-core/tsconfig.json
+++ b/packages/outbox-core/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022", "dom"],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": false,
+    "types": ["node", "vitest/globals"],
+    "strict": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "importHelpers": true,
+    "baseUrl": ".",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["lib/**/*.ts", "test/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/outbox-core/tsconfig.release.json
+++ b/packages/outbox-core/tsconfig.release.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["lib/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist", "lib/**/*.spec.ts"]
+}

--- a/packages/outbox-core/vitest.config.mts
+++ b/packages/outbox-core/vitest.config.mts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    watch: false,
+    environment: 'node',
+    reporters: ['default'],
+    coverage: {
+      provider: 'v8',
+      include: ['lib/**/*.ts'],
+      exclude: ['lib/**/*.spec.ts', 'lib/**/*.test.ts', 'test/**/*.*'],
+      reporter: ['text'],
+      all: true,
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 91.66,
+        statements: 100,
+      },
+    },
+  },
+})


### PR DESCRIPTION
Added few classes in outbox.ts that cover:
- Periodic job that runs every 1 sec to process entries from outbox storage
- OutboxStorage interface -> next step, implement prisma

I didn't decide to implement `lockedUntil` for `ACKed` entries. Now the code that handles entries is wrapped with try-catch, in case of errors we always end up with `FAILED` status, next execution will pick up such entries until retry count max is reached.