### PR TITLE
patch version mqt core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/core",
-  "version": "17.2.0",
+  "version": "17.2.1",
   "private": false,
   "license": "MIT",
   "description": "Useful utilities, interfaces and base classes for message queue handling. Supports AMQP and SQS with a common abstraction on top currently",


### PR DESCRIPTION
Release prepare for MQT core due to the following error: 
```
Property '[internalErrorSymbol]' is missing in type 'import("/Users/carlos.gamero@lokalise.com/development/Node/autopilot/node_modules/@lokalise/node-core/dist/index").InternalError<import("/Users/carlos.gamero@lokalise.com/development/Node/autopilot/node_modules/@lokalise/node-core/dist/index").ErrorDetails>' but required in type 'import("/Users/carlos.gamero@lokalise.com/development/Node/autopilot/node_modules/@message-queue-toolkit/core/node_modules/@lokalise/node-core/dist/src/errors/InternalError
```
I think it is due to SNS and SQS are using node-core 13 but the released version of mqt-core is using node-core 12. So preparing this release to fix the type issue