### PR TITLE
AMQP release prepare for node-core 13

### DIFF
--- a/packages/amqp/package.json
+++ b/packages/amqp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/amqp",
-  "version": "16.1.1",
+  "version": "16.2.0",
   "private": false,
   "license": "MIT",
   "description": "AMQP adapter for message-queue-toolkit",
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run build:release"
   },
   "dependencies": {
-    "@lokalise/node-core": "^13.0.1",
+    "@lokalise/node-core": "^13.0.0",
     "zod": "^3.23.8"
   },
   "peerDependencies": {

--- a/packages/amqp/package.json
+++ b/packages/amqp/package.json
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run build:release"
   },
   "dependencies": {
-    "@lokalise/node-core": "^13.0.0",
+    "@lokalise/node-core": "^13.1.0",
     "zod": "^3.23.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
The current released version of AMQP is using node-core 12, and it is producing error on Maestro due to some type discrepancies with InternalError