### PR TITLE
Concurrent consumers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Multi-schema consumers support multiple message types via handler configs. They 
         * `handlerSpy` - allow awaiting certain messages to be published (see [Handler Spies](#handler-spies) for more information);
         * `logMessages` - add logs for processed messages.
         * `payloadStoreConfig` - configuration for payload offloading. This option enables the external storage of large message payloads to comply with message size limitations of the queue system. For more details on setting this up, see [Payload Offloading](#payload-offloading).
+        * `concurrentConsumersAmount` - configuration for specifying the number of concurrent consumers to create. Available only for SQS consumers
 * `init()`, prepare consumer for use (e. g. establish all necessary connections);
 * `close()`, stop listening for messages and disconnect;
 * `start()`, which invokes `init()`.

--- a/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
+++ b/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
@@ -91,7 +91,7 @@ describe('AmqpPermissionConsumer', () => {
       await newConsumer.handlerSpy.waitForMessageWithId('1', 'consumed')
 
       expect(logger.loggedMessages.length).toBe(5)
-      expect(logger.loggedMessages).toEqual([
+      expect(logger.loggedMessages).toMatchObject([
         'Propagating new connection across 0 receivers',
         {
           id: '1',

--- a/packages/core/lib/queues/AbstractQueueService.ts
+++ b/packages/core/lib/queues/AbstractQueueService.ts
@@ -165,14 +165,22 @@ export abstract class AbstractQueueService<
   }
 
   protected logProcessedMessage(
-    _message: MessagePayloadSchemas | null,
+    message: MessagePayloadSchemas | null,
     processingResult: MessageProcessingResult,
     messageId?: string,
   ) {
+    const messageTimestamp = message ? this.tryToExtractTimestamp(message) : undefined
+    const messageProcessingMilliseconds = messageTimestamp ? Date.now() - messageTimestamp.getTime() : undefined
+
+    // @ts-ignore
+    const messageType = (message && this.messageTypeField in message) ? message[this.messageTypeField] : undefined
+
     this.logger.debug(
       {
         processingResult,
         messageId,
+        messageProcessingTime: messageProcessingMilliseconds,
+        messageType,
       },
       `Finished processing message ${messageId ?? `(unknown id)`}`,
     )
@@ -206,7 +214,6 @@ export abstract class AbstractQueueService<
     if (this.logMessages) {
       // @ts-ignore
       const resolvedMessageId: string | undefined = message?.[this.messageIdField] ?? messageId
-
       this.logProcessedMessage(message, processingResult, resolvedMessageId)
     }
   }

--- a/packages/core/lib/queues/AbstractQueueService.ts
+++ b/packages/core/lib/queues/AbstractQueueService.ts
@@ -170,10 +170,15 @@ export abstract class AbstractQueueService<
     messageId?: string,
   ) {
     const messageTimestamp = message ? this.tryToExtractTimestamp(message) : undefined
-    const messageProcessingMilliseconds = messageTimestamp ? Date.now() - messageTimestamp.getTime() : undefined
+    const messageProcessingMilliseconds = messageTimestamp
+      ? Date.now() - messageTimestamp.getTime()
+      : undefined
 
-    // @ts-ignore
-    const messageType = (message && this.messageTypeField in message) ? message[this.messageTypeField] : undefined
+    const messageType =
+      message && this.messageTypeField in message
+        ? // @ts-ignore
+          message[this.messageTypeField]
+        : undefined
 
     this.logger.debug(
       {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/core",
-  "version": "17.2.1",
+  "version": "17.2.3",
   "private": false,
   "license": "MIT",
   "description": "Useful utilities, interfaces and base classes for message queue handling. Supports AMQP and SQS with a common abstraction on top currently",

--- a/packages/outbox-core/package.json
+++ b/packages/outbox-core/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build:release"
   },
   "dependencies": {
-    "@lokalise/background-jobs-common": "^7.6.1",
+    "@lokalise/background-jobs-common": "^8.0.0",
     "@supercharge/promise-pool": "^3.2.0",
     "uuidv7": "^1.0.2"
   },

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sns",
-  "version": "18.0.1",
+  "version": "18.1.1",
   "private": false,
   "license": "MIT",
   "description": "SNS adapter for message-queue-toolkit",
@@ -35,7 +35,7 @@
     "@aws-sdk/client-sts": "^3.632.0",
     "@message-queue-toolkit/core": ">=15.0.0",
     "@message-queue-toolkit/schemas": ">=2.0.0",
-    "@message-queue-toolkit/sqs": "^17.0.0"
+    "@message-queue-toolkit/sqs": "^17.3.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.670.0",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sns",
-  "version": "18.1.1",
+  "version": "18.1.0",
   "private": false,
   "license": "MIT",
   "description": "SNS adapter for message-queue-toolkit",

--- a/packages/sns/test/consumers/SnsSqsPermissionConsumer.spec.ts
+++ b/packages/sns/test/consumers/SnsSqsPermissionConsumer.spec.ts
@@ -12,8 +12,8 @@ import { registerDependencies } from '../utils/testContext'
 import type { Dependencies } from '../utils/testContext'
 
 import type { STSClient } from '@aws-sdk/client-sts'
-import type { PERMISSIONS_ADD_MESSAGE_TYPE } from '@message-queue-toolkit/sqs/dist/test/consumers/userConsumerSchemas'
 import { SnsSqsPermissionConsumer } from './SnsSqsPermissionConsumer'
+import type { PERMISSIONS_ADD_MESSAGE_TYPE } from './userConsumerSchemas'
 
 describe('SnsSqsPermissionConsumer', () => {
   describe('init', () => {

--- a/packages/sns/test/consumers/SnsSqsPermissionConsumer.ts
+++ b/packages/sns/test/consumers/SnsSqsPermissionConsumer.ts
@@ -39,6 +39,7 @@ type SnsSqsPermissionConsumerOptions = Pick<
   | 'consumerOverrides'
   | 'maxRetryDuration'
   | 'payloadStoreConfig'
+  | 'concurrentConsumersAmount'
 > & {
   addPreHandlerBarrier?: (
     message: SupportedMessages,
@@ -65,6 +66,7 @@ export class SnsSqsPermissionConsumer extends AbstractSnsSqsConsumer<
   public addBarrierCounter = 0
   public removeCounter = 0
   public preHandlerCounter = 0
+  public processedMessagesIds: Set<string> = new Set()
 
   constructor(
     dependencies: SNSSQSConsumerDependencies,
@@ -101,6 +103,7 @@ export class SnsSqsPermissionConsumer extends AbstractSnsSqsConsumer<
             PERMISSIONS_ADD_MESSAGE_SCHEMA,
             (_message, context, _preHandlingOutputs) => {
               this.addCounter += context.incrementAmount
+              this.processedMessagesIds.add(_message.id)
               return Promise.resolve({ result: 'success' })
             },
             {
@@ -164,6 +167,7 @@ export class SnsSqsPermissionConsumer extends AbstractSnsSqsConsumer<
           updateAttributesIfExists: false,
         },
         maxRetryDuration: options.maxRetryDuration,
+        concurrentConsumersAmount: options.concurrentConsumersAmount,
       },
       {
         incrementAmount: 1,

--- a/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
@@ -181,14 +181,9 @@ export abstract class AbstractSqsConsumer<
 
     const visibilityTimeout = await this.getQueueVisibilityTimeout()
 
-    try {
-      this.consumers = Array.from({ length: this.concurrentConsumersAmount })
-        .map((_) => this.createConsumer({ visibilityTimeout }))
-    } catch (err) {
-      console.log(err)
-      console.log(this.consumers)
-    }
-
+    this.consumers = Array.from({ length: this.concurrentConsumersAmount }).map((_) =>
+      this.createConsumer({ visibilityTimeout }),
+    )
 
     for (const consumer of this.consumers) {
       consumer.on('error', (err) => {
@@ -283,7 +278,7 @@ export abstract class AbstractSqsConsumer<
   private stopExistingConsumers(abort?: boolean) {
     for (const consumer of this.consumers) {
       consumer.stop({
-        abort
+        abort,
       })
     }
   }

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sqs",
-  "version": "17.2.0",
+  "version": "17.3.0",
   "private": false,
   "license": "MIT",
   "description": "SQS adapter for message-queue-toolkit",

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
@@ -613,8 +613,7 @@ describe('SqsPermissionConsumer', () => {
                 QueueName: SqsPermissionConsumer.QUEUE_NAME,
               },
             },
-            concurrentConsumersAmount: 10,
-            logMessages: true,
+            concurrentConsumersAmount: 5,
           })
         }),
       })
@@ -646,12 +645,8 @@ describe('SqsPermissionConsumer', () => {
         }),
       )
 
-      await Promise.all(
-        messages.map(async (m) => {
-          await publisher.publish(m)
-          await consumer.handlerSpy.waitForMessageWithId(m.id, 'consumed')
-        }),
-      )
+      messages.map(m => publisher.publish(m))
+      await Promise.all(messages.map((m) => consumer.handlerSpy.waitForMessageWithId(m.id, 'consumed')))
 
       // Verifies that each message is executed only once
       expect(consumer.addCounter).toBe(messagesAmount)

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
@@ -645,8 +645,10 @@ describe('SqsPermissionConsumer', () => {
         }),
       )
 
-      messages.map(m => publisher.publish(m))
-      await Promise.all(messages.map((m) => consumer.handlerSpy.waitForMessageWithId(m.id, 'consumed')))
+      messages.map((m) => publisher.publish(m))
+      await Promise.all(
+        messages.map((m) => consumer.handlerSpy.waitForMessageWithId(m.id, 'consumed')),
+      )
 
       // Verifies that each message is executed only once
       expect(consumer.addCounter).toBe(messagesAmount)

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
@@ -21,7 +21,7 @@ import { SINGLETON_CONFIG, registerDependencies } from '../utils/testContext'
 import type { Dependencies } from '../utils/testContext'
 
 import { SqsPermissionConsumer } from './SqsPermissionConsumer'
-import type { PERMISSIONS_ADD_MESSAGE_TYPE } from "./userConsumerSchemas";
+import type { PERMISSIONS_ADD_MESSAGE_TYPE } from './userConsumerSchemas'
 
 describe('SqsPermissionConsumer', () => {
   describe('init', () => {
@@ -606,7 +606,7 @@ describe('SqsPermissionConsumer', () => {
 
     beforeEach(async () => {
       diContainer = await registerDependencies({
-        permissionConsumer: asFunction(dependencies => {
+        permissionConsumer: asFunction((dependencies) => {
           return new SqsPermissionConsumer(dependencies, {
             creationConfig: {
               queue: {
@@ -616,7 +616,7 @@ describe('SqsPermissionConsumer', () => {
             concurrentConsumersAmount: 10,
             logMessages: true,
           })
-        })
+        }),
       })
       sqsClient = diContainer.cradle.sqsClient
       publisher = diContainer.cradle.permissionPublisher
@@ -638,16 +638,20 @@ describe('SqsPermissionConsumer', () => {
 
     it('process all messages properly', async () => {
       const messagesAmount = 100
-      const messages: PERMISSIONS_ADD_MESSAGE_TYPE[] = Array.from({ length: messagesAmount }).map((_, i) => ({
-        id: `${i}`,
-        messageType: 'add',
-        timestamp: new Date().toISOString(),
-      }))
+      const messages: PERMISSIONS_ADD_MESSAGE_TYPE[] = Array.from({ length: messagesAmount }).map(
+        (_, i) => ({
+          id: `${i}`,
+          messageType: 'add',
+          timestamp: new Date().toISOString(),
+        }),
+      )
 
-      await Promise.all(messages.map(async (m) => {
-        await publisher.publish(m)
-        await consumer.handlerSpy.waitForMessageWithId(m.id, 'consumed')
-      }))
+      await Promise.all(
+        messages.map(async (m) => {
+          await publisher.publish(m)
+          await consumer.handlerSpy.waitForMessageWithId(m.id, 'consumed')
+        }),
+      )
 
       // Verifies that each message is executed only once
       expect(consumer.addCounter).toBe(messagesAmount)

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
@@ -21,6 +21,7 @@ import { SINGLETON_CONFIG, registerDependencies } from '../utils/testContext'
 import type { Dependencies } from '../utils/testContext'
 
 import { SqsPermissionConsumer } from './SqsPermissionConsumer'
+import type { PERMISSIONS_ADD_MESSAGE_TYPE } from "./userConsumerSchemas";
 
 describe('SqsPermissionConsumer', () => {
   describe('init', () => {
@@ -593,6 +594,65 @@ describe('SqsPermissionConsumer', () => {
 
       expect(consumer.addCounter).toBe(1)
       expect(consumer.removeCounter).toBe(2)
+    })
+  })
+
+  describe('multiple consumers', () => {
+    let diContainer: AwilixContainer<Dependencies>
+    let sqsClient: SQSClient
+
+    let publisher: SqsPermissionPublisher
+    let consumer: SqsPermissionConsumer
+
+    beforeEach(async () => {
+      diContainer = await registerDependencies({
+        permissionConsumer: asFunction(dependencies => {
+          return new SqsPermissionConsumer(dependencies, {
+            creationConfig: {
+              queue: {
+                QueueName: SqsPermissionConsumer.QUEUE_NAME,
+              },
+            },
+            concurrentConsumersAmount: 10,
+            logMessages: true,
+          })
+        })
+      })
+      sqsClient = diContainer.cradle.sqsClient
+      publisher = diContainer.cradle.permissionPublisher
+      consumer = diContainer.cradle.permissionConsumer
+
+      await consumer.start()
+
+      const command = new ReceiveMessageCommand({
+        QueueUrl: publisher.queueProps.url,
+      })
+      const reply = await sqsClient.send(command)
+      expect(reply.Messages).toBeUndefined()
+    })
+
+    afterEach(async () => {
+      await diContainer.cradle.awilixManager.executeDispose()
+      await diContainer.dispose()
+    })
+
+    it('process all messages properly', async () => {
+      const messagesAmount = 100
+      const messages: PERMISSIONS_ADD_MESSAGE_TYPE[] = Array.from({ length: messagesAmount }).map((_, i) => ({
+        id: `${i}`,
+        messageType: 'add',
+        timestamp: new Date().toISOString(),
+      }))
+
+      await Promise.all(messages.map(async (m) => {
+        await publisher.publish(m)
+        await consumer.handlerSpy.waitForMessageWithId(m.id, 'consumed')
+      }))
+
+      // Verifies that each message is executed only once
+      expect(consumer.addCounter).toBe(messagesAmount)
+      // Verifies that no message is lost
+      expect(consumer.processedMessagesIds).toHaveLength(messagesAmount)
     })
   })
 

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.ts
@@ -115,7 +115,7 @@ export class SqsPermissionConsumer extends AbstractSqsConsumer<
               }
               this.addCounter += context.incrementAmount
               this.processedMessagesIds.add(_message.id)
-              return Promise.resolve({result: 'success'})
+              return Promise.resolve({ result: 'success' })
             },
             {
               preHandlerBarrier: options.addPreHandlerBarrier,


### PR DESCRIPTION
Changes:
- instead of operating on `consumer` field in `AbstractSqsConsumer`, we use `consumers` array now
- number of consumers can be specified with `concurrentConsumersAmount` option
- added `messageProcessingTime` and `messageType` to the log for better observability