### PR TITLE
Message processing metric improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ It needs to implement the following methods:
   - `messageType`
   - `processingResult` - can have one of the following values: `retryLater`, `consumed`, `published`, `error`, `invalid_message`
   - `message` - whole message object
+  - `queueName` - name of the queue or topic on which message is consumed or published
   - `messageProcessingMilliseconds` - message processing time in milliseconds
 
 See [@message-queue-toolkit/metrics](packages/metrics/README.md) for concrete implementations

--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ It needs to implement the following methods:
   - `processingResult` - can have one of the following values: `retryLater`, `consumed`, `published`, `error`, `invalid_message`
   - `message` - whole message object
   - `queueName` - name of the queue or topic on which message is consumed or published
-  - `messageProcessingMilliseconds` - message processing time in milliseconds
+  - `messageTimestamp` - the timestamp when the message was sent initially
+  - `messageProcessingStartTimestamp` - the timestamp when the processing of the message started
+  - `messageProcessingEndTimestamp` - the timestamp when the processing of the message finished
 
 See [@message-queue-toolkit/metrics](packages/metrics/README.md) for concrete implementations

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,17 +3,42 @@
 ## Upgrading </br> `core` `18.0.0` -> `19.0.0` </br> `sqs` `18.0.0` -> `19.0.0` </br> `sns` `19.0.0` -> `20.0.0` </br> `amqp` `17.0.0` -> `18.0.0`
 
 ### Description of Breaking Changes
-In `AbstractQueueService`:
-- `handleMessageProcessed` method signature has changed. It now accepts 2 additional parameters:
-  - `messageProcessingStartTimestamp` - timestamp in milliseconds used to calculate message processing time
-  - `queueName` - name of the queue or topic on which message is consumed or published
-- `resolveProcessedMessageMetadata` was made private
+- In `AbstractQueueService`:
+  - `handleMessageProcessed` method signature has changed. It now accepts 2 additional parameters:
+    - `messageProcessingStartTimestamp` - timestamp in milliseconds used to calculate message processing time
+    - `queueName` - name of the queue or topic on which message is consumed or published
+  - `resolveProcessedMessageMetadata` was made private
+
+- `ProcessedMessageMetadata` type used in `MessageMetricsManager` has changed:
+  - `messageProcessingMilliseconds` property was removed
+  - the following properties were added:
+    - `messageTimestamp`
+    - `messageProcessingStartTimestamp`
+    - `messageProcessingEndTimestamp`
+
+- Because of the change above, `@message-queue-toolkit/metrics@1.0.0` is not compatible with the new version.
 
 ### Migration steps
-If you are extending `AbstractQueueService` and calling `handleMessageProcessed` manually, you need to provide additional parameters, e.g.:
-```typescript
-this.handleMessageProcessed(message, 'consumed', messageProcessingStartTimestamp, queueName)
-```
+- If you are using custom implementation of `MessageMetricsManager`, you may need to adjust it to the new properties in `ProcessedMessageMetadata`
+
+- If you are extending `AbstractQueueService` and calling `handleMessageProcessed` manually, you need to provide additional parameters, e.g.:
+    ```typescript
+    this.handleMessageProcessed(message, 'consumed', messageProcessingStartTimestamp, queueName)
+    ```
+
+- If you are using features from `@message-queue-toolkit/metrics@1.0.0`, upgrade to `@message-queue-toolkit/metrics@2.0.0` and follow the migration guide below.
+
+## Upgrading `metrics` from `1.0.0 `to `2.0.0`
+
+### Description of Breaking Changes
+- `MessageProcessingTimePrometheusMetric` class was replaced by 2 classes:
+    - `MessageProcessingTimeMetric` - registers elapsed time from start to the end of processing
+    - `MessageLifetimeMetric` - registers elapsed time from message creation to the end of processing
+
+### Migration steps
+- If you are using `MessageProcessingTimePrometheusMetric`, replace it with one of the metrics mentioned above, depending on what do you want to measure.
+  **Note:** if you want to keep current measurements, use `MessageLifetimeMetric`.
+  If you want to use both metrics, use `MessageProcessingMultiMetrics` (see: [README.md](packages/metrics/README.md))
 
 ## Upgrading </br> `core` `17.0.0` -> `18.0.0` </br> `sqs` `17.0.0` -> `18.0.0` </br> `sns` `18.0.0` -> `19.0.0` </br> `amqp` `16.0.0` -> `17.0.0`    
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,20 @@
 # Upgrading Guide
 
+## Upgrading </br> `core` `18.0.0` -> `19.0.0` </br> `sqs` `18.0.0` -> `19.0.0` </br> `sns` `19.0.0` -> `20.0.0` </br> `amqp` `17.0.0` -> `18.0.0`
+
+### Description of Breaking Changes
+In `AbstractQueueService`:
+- `handleMessageProcessed` method signature has changed. It now accepts 2 additional parameters:
+  - `messageProcessingStartTimestamp` - timestamp in milliseconds used to calculate message processing time
+  - `queueName` - name of the queue or topic on which message is consumed or published
+- `resolveProcessedMessageMetadata` was made private
+
+### Migration steps
+If you are extending `AbstractQueueService` and calling `handleMessageProcessed` manually, you need to provide additional parameters, e.g.:
+```typescript
+this.handleMessageProcessed(message, 'consumed', messageProcessingStartTimestamp, queueName)
+```
+
 ## Upgrading </br> `core` `17.0.0` -> `18.0.0` </br> `sqs` `17.0.0` -> `18.0.0` </br> `sns` `18.0.0` -> `19.0.0` </br> `amqp` `16.0.0` -> `17.0.0`    
 
 ### Description of Breaking Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,7 @@
 
 ### Description of Breaking Changes
 - In `AbstractQueueService`:
-  - `handleMessageProcessed` method signature has changed. It now accepts 2 additional parameters:
+  - `handleMessageProcessed` method signature has changed. Parameters are now passed as an object, and 2 additional properties were added:
     - `messageProcessingStartTimestamp` - timestamp in milliseconds used to calculate message processing time
     - `queueName` - name of the queue or topic on which message is consumed or published
   - `resolveProcessedMessageMetadata` was made private
@@ -21,9 +21,14 @@
 ### Migration steps
 - If you are using custom implementation of `MessageMetricsManager`, you may need to adjust it to the new properties in `ProcessedMessageMetadata`
 
-- If you are extending `AbstractQueueService` and calling `handleMessageProcessed` manually, you need to provide additional parameters, e.g.:
+- If you are extending `AbstractQueueService` and calling `handleMessageProcessed` manually, you need to adjust it to the new signature, e.g.:
+  - from:  
     ```typescript
     this.handleMessageProcessed(message, 'consumed', messageProcessingStartTimestamp, queueName)
+    ```
+  - to:
+    ```typescript
+    this.handleMessageProcessed({ message, processingResult: 'consumed', messageProcessingStartTimestamp, queueName })
     ```
 
 - If you are using features from `@message-queue-toolkit/metrics@1.0.0`, upgrade to `@message-queue-toolkit/metrics@2.0.0` and follow the migration guide below.

--- a/packages/amqp/lib/AbstractAmqpConsumer.ts
+++ b/packages/amqp/lib/AbstractAmqpConsumer.ts
@@ -139,13 +139,13 @@ export abstract class AbstractAmqpConsumer<
       if (deserializedMessage.error === 'abort') {
         this.channel.nack(message, false, false)
         const messageId = this.tryToExtractId(message)
-        this.handleMessageProcessed(
-          null,
-          'invalid_message',
+        this.handleMessageProcessed({
+          message: null,
+          processingResult: 'invalid_message',
           messageProcessingStartTimestamp,
-          this.queueName,
-          messageId.result,
-        )
+          queueName: this.queueName,
+          messageId: messageId.result,
+        })
         return
       }
       const { originalMessage, parsedMessage } = deserializedMessage.result
@@ -168,12 +168,12 @@ export abstract class AbstractAmqpConsumer<
         .then((result) => {
           if (result.result === 'success') {
             this.channel.ack(message)
-            this.handleMessageProcessed(
-              parsedMessage,
-              'consumed',
+            this.handleMessageProcessed({
+              message: parsedMessage,
+              processingResult: 'consumed',
               messageProcessingStartTimestamp,
-              this.queueName,
-            )
+              queueName: this.queueName,
+            })
             return
           }
 
@@ -181,33 +181,33 @@ export abstract class AbstractAmqpConsumer<
           if (this.shouldBeRetried(originalMessage, this.maxRetryDuration)) {
             // TODO: Add retry delay + republish message updating internal properties
             this.channel.nack(message, false, true)
-            this.handleMessageProcessed(
-              parsedMessage,
-              'retryLater',
+            this.handleMessageProcessed({
+              message: parsedMessage,
+              processingResult: 'retryLater',
               messageProcessingStartTimestamp,
-              this.queueName,
-            )
+              queueName: this.queueName,
+            })
           } else {
             // ToDo move message to DLQ once it is implemented
             this.channel.ack(message)
-            this.handleMessageProcessed(
-              parsedMessage,
-              'error',
+            this.handleMessageProcessed({
+              message: parsedMessage,
+              processingResult: 'error',
               messageProcessingStartTimestamp,
-              this.queueName,
-            )
+              queueName: this.queueName,
+            })
           }
         })
         .catch((err) => {
           // ToDo we need sanity check to stop trying at some point, perhaps some kind of Redis counter
           // If we fail due to unknown reason, let's retry
           this.channel.nack(message, false, true)
-          this.handleMessageProcessed(
-            parsedMessage,
-            'retryLater',
+          this.handleMessageProcessed({
+            message: parsedMessage,
+            processingResult: 'retryLater',
             messageProcessingStartTimestamp,
-            this.queueName,
-          )
+            queueName: this.queueName,
+          })
           this.handleError(err)
         })
         .finally(() => {

--- a/packages/amqp/package.json
+++ b/packages/amqp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/amqp",
-  "version": "17.1.0",
+  "version": "18.0.0",
   "private": false,
   "license": "MIT",
   "description": "AMQP adapter for message-queue-toolkit",
@@ -29,7 +29,7 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@message-queue-toolkit/core": ">=18.1.0",
+    "@message-queue-toolkit/core": ">=19.0.0",
     "@message-queue-toolkit/schemas": ">=2.0.0",
     "amqplib": "^0.10.3"
   },

--- a/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
+++ b/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
@@ -157,7 +157,9 @@ describe('AmqpPermissionConsumer', () => {
           messageType: 'add',
           processingResult: 'consumed',
           queueName: AmqpPermissionConsumer.QUEUE_NAME,
-          messageProcessingMilliseconds: expect.any(Number),
+          messageTimestamp: expect.any(Number),
+          messageProcessingStartTimestamp: expect.any(Number),
+          messageProcessingEndTimestamp: expect.any(Number),
           message: expect.objectContaining({
             id: '1',
             messageType: 'add',

--- a/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
+++ b/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
@@ -156,6 +156,7 @@ describe('AmqpPermissionConsumer', () => {
           messageId: '1',
           messageType: 'add',
           processingResult: 'consumed',
+          queueName: AmqpPermissionConsumer.QUEUE_NAME,
           messageProcessingMilliseconds: expect.any(Number),
           message: expect.objectContaining({
             id: '1',

--- a/packages/core/lib/queues/AbstractQueueService.ts
+++ b/packages/core/lib/queues/AbstractQueueService.ts
@@ -190,6 +190,8 @@ export abstract class AbstractQueueService<
   protected handleMessageProcessed(
     message: MessagePayloadSchemas | null,
     processingResult: MessageProcessingResult,
+    messageProcessingStartTimestamp: number,
+    queueName: string,
     messageId?: string,
   ) {
     const messageProcessedTimestamp = Date.now()
@@ -212,7 +214,9 @@ export abstract class AbstractQueueService<
     const processedMessageMetadata = this.resolveProcessedMessageMetadata(
       message,
       processingResult,
+      messageProcessingStartTimestamp,
       messageProcessedTimestamp,
+      queueName,
       messageId,
     )
     if (debugLoggingEnabled) {
@@ -226,19 +230,18 @@ export abstract class AbstractQueueService<
     }
   }
 
-  protected resolveProcessedMessageMetadata(
+  private resolveProcessedMessageMetadata(
     message: MessagePayloadSchemas | null,
     processingResult: MessageProcessingResult,
+    messageProcessingStartTimestamp: number,
     messageProcessedTimestamp: number,
+    queueName: string,
     messageId?: string,
   ): ProcessedMessageMetadata<MessagePayloadSchemas> {
     // @ts-ignore
     const resolvedMessageId: string | undefined = message?.[this.messageIdField] ?? messageId
-
-    const messageTimestamp = message ? this.tryToExtractTimestamp(message) : undefined
-    const messageProcessingMilliseconds = messageTimestamp
-      ? messageProcessedTimestamp - messageTimestamp.getTime()
-      : undefined
+    const messageProcessingMilliseconds =
+      messageProcessedTimestamp - messageProcessingStartTimestamp
 
     const messageType =
       message && this.messageTypeField in message
@@ -251,6 +254,7 @@ export abstract class AbstractQueueService<
       messageId: resolvedMessageId ?? '(unknown id)',
       messageProcessingMilliseconds,
       messageType,
+      queueName,
       message,
     }
   }

--- a/packages/core/lib/queues/AbstractQueueService.ts
+++ b/packages/core/lib/queues/AbstractQueueService.ts
@@ -187,13 +187,14 @@ export abstract class AbstractQueueService<
     }
   }
 
-  protected handleMessageProcessed(
-    message: MessagePayloadSchemas | null,
-    processingResult: MessageProcessingResult,
-    messageProcessingStartTimestamp: number,
-    queueName: string,
-    messageId?: string,
-  ) {
+  protected handleMessageProcessed(params: {
+    message: MessagePayloadSchemas | null
+    processingResult: MessageProcessingResult
+    messageProcessingStartTimestamp: number
+    queueName: string
+    messageId?: string
+  }) {
+    const { message, processingResult, messageId } = params
     const messageProcessingEndTimestamp = Date.now()
 
     if (this._handlerSpy) {
@@ -214,9 +215,9 @@ export abstract class AbstractQueueService<
     const processedMessageMetadata = this.resolveProcessedMessageMetadata(
       message,
       processingResult,
-      messageProcessingStartTimestamp,
+      params.messageProcessingStartTimestamp,
       messageProcessingEndTimestamp,
-      queueName,
+      params.queueName,
       messageId,
     )
     if (debugLoggingEnabled) {

--- a/packages/core/lib/queues/AbstractQueueService.ts
+++ b/packages/core/lib/queues/AbstractQueueService.ts
@@ -194,7 +194,7 @@ export abstract class AbstractQueueService<
     queueName: string,
     messageId?: string,
   ) {
-    const messageProcessedTimestamp = Date.now()
+    const messageProcessingEndTimestamp = Date.now()
 
     if (this._handlerSpy) {
       this._handlerSpy.addProcessedMessage(
@@ -215,7 +215,7 @@ export abstract class AbstractQueueService<
       message,
       processingResult,
       messageProcessingStartTimestamp,
-      messageProcessedTimestamp,
+      messageProcessingEndTimestamp,
       queueName,
       messageId,
     )
@@ -234,15 +234,14 @@ export abstract class AbstractQueueService<
     message: MessagePayloadSchemas | null,
     processingResult: MessageProcessingResult,
     messageProcessingStartTimestamp: number,
-    messageProcessedTimestamp: number,
+    messageProcessingEndTimestamp: number,
     queueName: string,
     messageId?: string,
   ): ProcessedMessageMetadata<MessagePayloadSchemas> {
     // @ts-ignore
     const resolvedMessageId: string | undefined = message?.[this.messageIdField] ?? messageId
-    const messageProcessingMilliseconds =
-      messageProcessedTimestamp - messageProcessingStartTimestamp
 
+    const messageTimestamp = message ? this.tryToExtractTimestamp(message)?.getTime() : undefined
     const messageType =
       message && this.messageTypeField in message
         ? // @ts-ignore
@@ -252,10 +251,12 @@ export abstract class AbstractQueueService<
     return {
       processingResult,
       messageId: resolvedMessageId ?? '(unknown id)',
-      messageProcessingMilliseconds,
       messageType,
       queueName,
       message,
+      messageTimestamp,
+      messageProcessingStartTimestamp,
+      messageProcessingEndTimestamp,
     }
   }
 

--- a/packages/core/lib/types/queueOptionsTypes.ts
+++ b/packages/core/lib/types/queueOptionsTypes.ts
@@ -39,9 +39,20 @@ export type ProcessedMessageMetadata<MessagePayloadSchemas extends object = obje
   queueName: string
 
   /**
-   * Processing time in milliseconds
+   * The timestamp when the message was sent initially, in milliseconds since the epoch
    */
-  messageProcessingMilliseconds?: number
+  messageTimestamp: number | undefined
+
+  /**
+   * The timestamp when the processing of the message begins, in milliseconds since the epoch
+   * Note: for publishers the value may be smaller than messageTimestamp
+   */
+  messageProcessingStartTimestamp: number
+
+  /**
+   * The timestamp when the processing of the message ends, in milliseconds since the epoch
+   */
+  messageProcessingEndTimestamp: number
 }
 
 export interface MessageMetricsManager<MessagePayloadSchemas extends object = object> {

--- a/packages/core/lib/types/queueOptionsTypes.ts
+++ b/packages/core/lib/types/queueOptionsTypes.ts
@@ -34,6 +34,11 @@ export type ProcessedMessageMetadata<MessagePayloadSchemas extends object = obje
   message: MessagePayloadSchemas | null
 
   /**
+   * Name of the queue processing the message
+   */
+  queueName: string
+
+  /**
    * Processing time in milliseconds
    */
   messageProcessingMilliseconds?: number

--- a/packages/core/lib/types/queueOptionsTypes.ts
+++ b/packages/core/lib/types/queueOptionsTypes.ts
@@ -44,13 +44,13 @@ export type ProcessedMessageMetadata<MessagePayloadSchemas extends object = obje
   messageTimestamp: number | undefined
 
   /**
-   * The timestamp when the processing of the message begins, in milliseconds since the epoch
+   * The timestamp when the processing of the message began, in milliseconds since the epoch
    * Note: for publishers the value may be smaller than messageTimestamp
    */
   messageProcessingStartTimestamp: number
 
   /**
-   * The timestamp when the processing of the message ends, in milliseconds since the epoch
+   * The timestamp when the processing of the message ended, in milliseconds since the epoch
    */
   messageProcessingEndTimestamp: number
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/core",
-  "version": "18.1.0",
+  "version": "19.0.0",
   "private": false,
   "license": "MIT",
   "description": "Useful utilities, interfaces and base classes for message queue handling. Supports AMQP and SQS with a common abstraction on top currently",

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -10,6 +10,10 @@ Metrics that use [Prometheus](https://prometheus.io/) toolkit and [prom-client](
 
 Implementation of `MessageMetricsManager` that can be injected into `AbstractQueueService` from `@message-queue-toolkit/core`.
 
-It uses [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) metric to collect message processing times with `messageType` and `version` labels.
+It uses [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) metric to collect message processing times with labels:
+- `messageType` - message type
+- `version` - message version
+- `queue` - name of the queue or topic
+- `result` - processing result
 
 See [MessageProcessingTimePrometheusMetric.ts](lib/prometheus/MessageProcessingTimePrometheusMetric.ts) for available parameters.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -6,9 +6,8 @@ This packages contains utilities for collecting metrics in `@message-queue-toolk
 
 Metrics that use [Prometheus](https://prometheus.io/) toolkit and [prom-client](https://github.com/siimon/prom-client) library
 
-### MessageProcessingTimePrometheusMetric
-
-Implementation of `MessageMetricsManager` that can be injected into `AbstractQueueService` from `@message-queue-toolkit/core`.
+### MessageProcessingPrometheusMetric
+Abstract class implementing `MessageMetricsManager` interface, that can be injected into `AbstractQueueService` from `@message-queue-toolkit/core`.
 
 It uses [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) metric to collect message processing times with labels:
 - `messageType` - message type
@@ -16,4 +15,13 @@ It uses [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram)
 - `queue` - name of the queue or topic
 - `result` - processing result
 
-See [MessageProcessingTimePrometheusMetric.ts](lib/prometheus/MessageProcessingTimePrometheusMetric.ts) for available parameters.
+See [MessageProcessingPrometheusMetric.ts](lib/prometheus/MessageProcessingPrometheusMetric.ts) for available parameters.
+
+There are following non-abstract implementations available:
+- `MessageProcessingTimeMetric` - registers elapsed time from start to the end of message processing
+- `MessageLifetimeMetric` - registers elapsed time from the point where message was initially sent, to the point when it was processed. 
+Note: if message is waiting in the queue due to high load or barrier, the waiting time is included in the measurement
+
+### MessageProcessingMultiMetrics
+Implementation of `MessageMetricsManager` that allows to use multiple `MessageProcessingPrometheusMetric` instances.
+

--- a/packages/metrics/index.ts
+++ b/packages/metrics/index.ts
@@ -1,1 +1,4 @@
-export { MessageProcessingTimePrometheusMetric } from './lib/prometheus/MessageProcessingTimePrometheusMetric'
+export { MessageLifetimeMetric } from './lib/prometheus/MessageLifetimeMetric'
+export { MessageProcessingMultiMetrics } from './lib/prometheus/MessageProcessingMultiMetrics'
+export { MessageProcessingPrometheusMetric } from './lib/prometheus/MessageProcessingPrometheusMetric'
+export { MessageProcessingTimeMetric } from './lib/prometheus/MessageProcessingTimeMetric'

--- a/packages/metrics/lib/prometheus/MessageLifetimeMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/MessageLifetimeMetric.spec.ts
@@ -1,0 +1,106 @@
+import * as promClient from 'prom-client'
+import type { Histogram } from 'prom-client'
+import { describe, expect, it, vi } from 'vitest'
+import { MessageLifetimeMetric } from './MessageLifetimeMetric'
+
+type TestMessageSchema = {
+  id: string
+  messageType: 'test'
+  timestamp?: string
+  metadata?: {
+    schemaVersion: string
+  }
+}
+
+describe('MessageLifetimeMetric', () => {
+  it('registers values properly', () => {
+    // Given
+    const observedValues: { labels: Record<string, any>; value: number }[] = []
+    vi.spyOn(promClient.register, 'getSingleMetric').mockReturnValue({
+      observe(labels: Record<string, string | number>, value: number) {
+        observedValues.push({ labels, value })
+      },
+    } as Histogram)
+
+    const metric = new MessageLifetimeMetric<TestMessageSchema>(
+      {
+        name: 'Test metric',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+      },
+      promClient,
+    )
+
+    // When
+    const message: TestMessageSchema = {
+      id: '1',
+      messageType: 'test',
+      timestamp: new Date().toISOString(),
+    }
+
+    const timestamp = Date.now()
+    metric.registerProcessedMessage({
+      messageId: message.id,
+      messageType: message.messageType,
+      processingResult: 'consumed',
+      message: message,
+      queueName: 'test-queue',
+      messageTimestamp: timestamp,
+      messageProcessingStartTimestamp: timestamp + 50,
+      messageProcessingEndTimestamp: timestamp + 200,
+    })
+
+    // Then
+    expect(observedValues).toStrictEqual([
+      {
+        labels: {
+          messageType: 'test',
+          version: undefined,
+          result: 'consumed',
+          queue: 'test-queue',
+        },
+        value: 200,
+      },
+    ])
+  })
+
+  it('skips observation if message timestamp is not available', () => {
+    // Given
+    const observedValues: { labels: Record<string, any>; value: number }[] = []
+    vi.spyOn(promClient.register, 'getSingleMetric').mockReturnValue({
+      observe(labels: Record<string, string | number>, value: number) {
+        observedValues.push({ labels, value })
+      },
+    } as Histogram)
+
+    const metric = new MessageLifetimeMetric<TestMessageSchema>(
+      {
+        name: 'Test metric',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+      },
+      promClient,
+    )
+
+    // When
+    const message: TestMessageSchema = {
+      id: '1',
+      messageType: 'test',
+      timestamp: new Date().toISOString(),
+    }
+
+    metric.registerProcessedMessage({
+      messageId: message.id,
+      messageType: message.messageType,
+      processingResult: 'consumed',
+      queueName: 'test-queue',
+      message: message,
+      messageTimestamp: undefined,
+      messageProcessingStartTimestamp: Date.now(),
+      messageProcessingEndTimestamp: Date.now(),
+    })
+
+    // Then
+    expect(observedValues).toStrictEqual([])
+  })
+})

--- a/packages/metrics/lib/prometheus/MessageLifetimeMetric.ts
+++ b/packages/metrics/lib/prometheus/MessageLifetimeMetric.ts
@@ -1,0 +1,15 @@
+import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
+import { MessageProcessingPrometheusMetric } from './MessageProcessingPrometheusMetric'
+
+export class MessageLifetimeMetric<
+  MessagePayloadSchemas extends object,
+> extends MessageProcessingPrometheusMetric<MessagePayloadSchemas> {
+  protected calculateObservedValue(
+    metadata: ProcessedMessageMetadata<MessagePayloadSchemas>,
+  ): number | null {
+    if (!metadata.messageTimestamp) {
+      return null
+    }
+    return metadata.messageProcessingEndTimestamp - metadata.messageTimestamp
+  }
+}

--- a/packages/metrics/lib/prometheus/MessageProcessingMultiMetrics.spec.ts
+++ b/packages/metrics/lib/prometheus/MessageProcessingMultiMetrics.spec.ts
@@ -1,0 +1,92 @@
+import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
+import * as promClient from 'prom-client'
+import { describe, expect, it } from 'vitest'
+import { MessageLifetimeMetric } from './MessageLifetimeMetric'
+import { MessageProcessingMultiMetrics } from './MessageProcessingMultiMetrics'
+import { MessageProcessingTimeMetric } from './MessageProcessingTimeMetric'
+
+type TestMessageSchema = {
+  id: string
+  messageType: 'test'
+  timestamp?: string
+  metadata?: {
+    schemaVersion: string
+  }
+}
+
+describe('MessageProcessingMultiMetrics', () => {
+  it('registers multiple metrics', () => {
+    // Given
+    const registeredProcessingTimeValues: ProcessedMessageMetadata<TestMessageSchema>[] = []
+    const registeredLifetimeValues: ProcessedMessageMetadata<TestMessageSchema>[] = []
+
+    const processingTimeMetric = new MessageProcessingTimeMetric<TestMessageSchema>(
+      {
+        name: 'test_processing_time',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+        messageVersion: (metadata: ProcessedMessageMetadata<TestMessageSchema>) => {
+          registeredProcessingTimeValues.push(metadata) // Mocking it to check if value is registered properly
+          return undefined
+        },
+      },
+      promClient,
+    )
+
+    const lifetimeMetric = new MessageLifetimeMetric<TestMessageSchema>(
+      {
+        name: 'test_processing_time',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+        messageVersion: (metadata: ProcessedMessageMetadata<TestMessageSchema>) => {
+          registeredLifetimeValues.push(metadata) // Mocking it to check if value is registered properly
+          return undefined
+        },
+      },
+      promClient,
+    )
+
+    const multiMetric = new MessageProcessingMultiMetrics<TestMessageSchema>([
+      processingTimeMetric,
+      lifetimeMetric,
+    ])
+
+    // When
+    const messages: TestMessageSchema[] = [
+      {
+        id: '1',
+        messageType: 'test',
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: '2',
+        messageType: 'test',
+        timestamp: new Date().toISOString(),
+        metadata: {
+          schemaVersion: '1.0.0',
+        },
+      },
+    ]
+
+    const timestamp = Date.now()
+    const processedMessageMetadataEntries: ProcessedMessageMetadata<TestMessageSchema>[] =
+      messages.map((message) => ({
+        messageId: message.id,
+        messageType: message.messageType,
+        processingResult: 'consumed',
+        message: message,
+        queueName: 'test-queue',
+        messageTimestamp: timestamp,
+        messageProcessingStartTimestamp: timestamp,
+        messageProcessingEndTimestamp: timestamp + 102,
+      }))
+
+    for (const processedMessageMetadata of processedMessageMetadataEntries) {
+      multiMetric.registerProcessedMessage(processedMessageMetadata)
+    }
+
+    // Then
+    expect(registeredProcessingTimeValues).toStrictEqual(processedMessageMetadataEntries)
+    expect(registeredLifetimeValues).toStrictEqual(processedMessageMetadataEntries)
+  })
+})

--- a/packages/metrics/lib/prometheus/MessageProcessingMultiMetrics.ts
+++ b/packages/metrics/lib/prometheus/MessageProcessingMultiMetrics.ts
@@ -1,0 +1,16 @@
+import type { MessageMetricsManager, ProcessedMessageMetadata } from '@message-queue-toolkit/core'
+import type { MessageProcessingPrometheusMetric } from './MessageProcessingPrometheusMetric'
+
+export class MessageProcessingMultiMetrics<MessagePayloadSchemas extends object>
+  implements MessageMetricsManager<MessagePayloadSchemas>
+{
+  constructor(
+    private readonly metrics: MessageProcessingPrometheusMetric<MessagePayloadSchemas>[],
+  ) {}
+
+  registerProcessedMessage(metadata: ProcessedMessageMetadata<MessagePayloadSchemas>): void {
+    for (const metric of this.metrics) {
+      metric.registerProcessedMessage(metadata)
+    }
+  }
+}

--- a/packages/metrics/lib/prometheus/MessageProcessingTimeMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/MessageProcessingTimeMetric.spec.ts
@@ -2,7 +2,7 @@ import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
 import * as promClient from 'prom-client'
 import type { Histogram } from 'prom-client'
 import { describe, expect, it, vi } from 'vitest'
-import { MessageProcessingTimePrometheusMetric } from './MessageProcessingTimePrometheusMetric'
+import { MessageProcessingTimeMetric } from './MessageProcessingTimeMetric'
 
 type TestMessageSchema = {
   id: string
@@ -13,11 +13,11 @@ type TestMessageSchema = {
   }
 }
 
-describe('MessageProcessingTimePrometheusMetric', () => {
+describe('MessageProcessingTimeMetric', () => {
   it('creates and uses Histogram metric properly', () => {
     // Given
     const registeredMessages: ProcessedMessageMetadata<TestMessageSchema>[] = []
-    const metric = new MessageProcessingTimePrometheusMetric<TestMessageSchema>(
+    const metric = new MessageProcessingTimeMetric<TestMessageSchema>(
       {
         name: 'test_metric',
         helpDescription: 'test description',
@@ -47,6 +47,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
       },
     ]
 
+    const timestamp = Date.now()
     const processedMessageMetadataEntries: ProcessedMessageMetadata<TestMessageSchema>[] =
       messages.map((message) => ({
         messageId: message.id,
@@ -54,7 +55,9 @@ describe('MessageProcessingTimePrometheusMetric', () => {
         processingResult: 'consumed',
         message: message,
         queueName: 'test-queue',
-        messageProcessingMilliseconds: 10,
+        messageTimestamp: timestamp,
+        messageProcessingStartTimestamp: timestamp,
+        messageProcessingEndTimestamp: timestamp + 102,
       }))
 
     for (const processedMessageMetadata of processedMessageMetadataEntries) {
@@ -74,7 +77,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
       },
     } as Histogram)
 
-    const metric = new MessageProcessingTimePrometheusMetric<TestMessageSchema>(
+    const metric = new MessageProcessingTimeMetric<TestMessageSchema>(
       {
         name: 'Test metric',
         helpDescription: 'test description',
@@ -90,13 +93,16 @@ describe('MessageProcessingTimePrometheusMetric', () => {
       timestamp: new Date().toISOString(),
     }
 
+    const timestamp = Date.now()
     metric.registerProcessedMessage({
       messageId: message.id,
       messageType: message.messageType,
       processingResult: 'consumed',
       message: message,
       queueName: 'test-queue',
-      messageProcessingMilliseconds: 111,
+      messageTimestamp: timestamp,
+      messageProcessingStartTimestamp: timestamp,
+      messageProcessingEndTimestamp: timestamp + 102,
     })
 
     // Then
@@ -108,7 +114,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
           result: 'consumed',
           queue: 'test-queue',
         },
-        value: 111,
+        value: 102,
       },
     ])
   })
@@ -122,7 +128,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
       },
     } as Histogram)
 
-    const metric = new MessageProcessingTimePrometheusMetric<TestMessageSchema>(
+    const metric = new MessageProcessingTimeMetric<TestMessageSchema>(
       {
         name: 'Test metric',
         helpDescription: 'test description',
@@ -152,13 +158,16 @@ describe('MessageProcessingTimePrometheusMetric', () => {
     ]
 
     for (const message of messages) {
+      const timestamp = Date.now()
       metric.registerProcessedMessage({
         messageId: message.id,
         messageType: message.messageType,
         processingResult: 'consumed',
         message: message,
         queueName,
-        messageProcessingMilliseconds: 10,
+        messageTimestamp: Date.now(),
+        messageProcessingStartTimestamp: timestamp,
+        messageProcessingEndTimestamp: timestamp + 53,
       })
     }
 
@@ -171,7 +180,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
           result: 'consumed',
           queue: queueName,
         },
-        value: 10,
+        value: 53,
       },
       {
         labels: {
@@ -180,45 +189,8 @@ describe('MessageProcessingTimePrometheusMetric', () => {
           result: 'consumed',
           queue: queueName,
         },
-        value: 10,
+        value: 53,
       },
     ])
-  })
-
-  it('skips observation if message processing time is not available', () => {
-    // Given
-    const observedValues: { labels: Record<string, any>; value: number }[] = []
-    vi.spyOn(promClient.register, 'getSingleMetric').mockReturnValue({
-      observe(labels: Record<string, string | number>, value: number) {
-        observedValues.push({ labels, value })
-      },
-    } as Histogram)
-
-    const metric = new MessageProcessingTimePrometheusMetric<TestMessageSchema>(
-      {
-        name: 'Test metric',
-        helpDescription: 'test description',
-        buckets: [1, 2, 3],
-      },
-      promClient,
-    )
-
-    // When
-    const message: TestMessageSchema = {
-      id: '1',
-      messageType: 'test',
-      timestamp: new Date().toISOString(),
-    }
-
-    metric.registerProcessedMessage({
-      messageId: message.id,
-      messageType: message.messageType,
-      processingResult: 'consumed',
-      queueName: 'test-queue',
-      message: message,
-    })
-
-    // Then
-    expect(observedValues).toStrictEqual([])
   })
 })

--- a/packages/metrics/lib/prometheus/MessageProcessingTimeMetric.ts
+++ b/packages/metrics/lib/prometheus/MessageProcessingTimeMetric.ts
@@ -1,0 +1,12 @@
+import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
+import { MessageProcessingPrometheusMetric } from './MessageProcessingPrometheusMetric'
+
+export class MessageProcessingTimeMetric<
+  MessagePayloadSchemas extends object,
+> extends MessageProcessingPrometheusMetric<MessagePayloadSchemas> {
+  protected calculateObservedValue(
+    metadata: ProcessedMessageMetadata<MessagePayloadSchemas>,
+  ): number | null {
+    return metadata.messageProcessingEndTimestamp - metadata.messageProcessingStartTimestamp
+  }
+}

--- a/packages/metrics/lib/prometheus/MessageProcessingTimePrometheusMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/MessageProcessingTimePrometheusMetric.spec.ts
@@ -53,6 +53,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
         messageType: message.messageType,
         processingResult: 'consumed',
         message: message,
+        queueName: 'test-queue',
         messageProcessingMilliseconds: 10,
       }))
 
@@ -94,6 +95,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
       messageType: message.messageType,
       processingResult: 'consumed',
       message: message,
+      queueName: 'test-queue',
       messageProcessingMilliseconds: 111,
     })
 
@@ -103,6 +105,8 @@ describe('MessageProcessingTimePrometheusMetric', () => {
         labels: {
           messageType: 'test',
           version: undefined,
+          result: 'consumed',
+          queue: 'test-queue',
         },
         value: 111,
       },
@@ -130,6 +134,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
     )
 
     // When
+    const queueName = 'test-queue'
     const messages: TestMessageSchema[] = [
       {
         id: '1',
@@ -152,6 +157,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
         messageType: message.messageType,
         processingResult: 'consumed',
         message: message,
+        queueName,
         messageProcessingMilliseconds: 10,
       })
     }
@@ -162,6 +168,8 @@ describe('MessageProcessingTimePrometheusMetric', () => {
         labels: {
           messageType: 'test',
           version: undefined,
+          result: 'consumed',
+          queue: queueName,
         },
         value: 10,
       },
@@ -169,6 +177,8 @@ describe('MessageProcessingTimePrometheusMetric', () => {
         labels: {
           messageType: 'test',
           version: '1.0.0',
+          result: 'consumed',
+          queue: queueName,
         },
         value: 10,
       },
@@ -204,6 +214,7 @@ describe('MessageProcessingTimePrometheusMetric', () => {
       messageId: message.id,
       messageType: message.messageType,
       processingResult: 'consumed',
+      queueName: 'test-queue',
       message: message,
     })
 

--- a/packages/metrics/lib/prometheus/MessageProcessingTimePrometheusMetric.ts
+++ b/packages/metrics/lib/prometheus/MessageProcessingTimePrometheusMetric.ts
@@ -31,7 +31,7 @@ type MessageVersionGeneratingFunction<T extends object> = (
   messageMetadata: ProcessedMessageMetadata<T>,
 ) => string | undefined
 
-/**
+/**w
  * Implementation of MessageMetricsManager that can be used to register message processing time in Prometheus, utilizing Histogram
  */
 export class MessageProcessingTimePrometheusMetric<MessagePayloadSchemas extends object>
@@ -40,7 +40,7 @@ export class MessageProcessingTimePrometheusMetric<MessagePayloadSchemas extends
   private readonly metricParams: PrometheusMetricParams<MessagePayloadSchemas>
 
   /** Fallbacks to null if metrics are disabled on app level */
-  private readonly metric: Histogram<'messageType' | 'version'>
+  private readonly metric: Histogram<'messageType' | 'version' | 'queue' | 'result'>
 
   private readonly messageVersionGeneratingFunction: MessageVersionGeneratingFunction<MessagePayloadSchemas>
 
@@ -68,6 +68,8 @@ export class MessageProcessingTimePrometheusMetric<MessagePayloadSchemas extends
       {
         messageType: metadata.messageType,
         version: this.messageVersionGeneratingFunction(metadata),
+        queue: metadata.queueName,
+        result: metadata.processingResult,
       },
       metadata.messageProcessingMilliseconds,
     )
@@ -84,7 +86,7 @@ export class MessageProcessingTimePrometheusMetric<MessagePayloadSchemas extends
       name: this.metricParams.name,
       help: this.metricParams.helpDescription,
       buckets: this.metricParams.buckets,
-      labelNames: ['messageType', 'version'],
+      labelNames: ['messageType', 'version', 'queue', 'result'],
     })
   }
 

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/metrics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "license": "MIT",
   "description": "Utilities for collecting metrics in message-queue-toolkit",
@@ -26,7 +26,7 @@
     "@lokalise/node-core": "^13.3.0"
   },
   "peerDependencies": {
-    "@message-queue-toolkit/core": ">=18.1.0",
+    "@message-queue-toolkit/core": ">=19.0.0",
     "prom-client": ">=15.0.0"
   },
   "devDependencies": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/metrics",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "private": false,
   "license": "MIT",
   "description": "Utilities for collecting metrics in message-queue-toolkit",

--- a/packages/sns/lib/sns/AbstractSnsPublisher.ts
+++ b/packages/sns/lib/sns/AbstractSnsPublisher.ts
@@ -80,12 +80,12 @@ export abstract class AbstractSnsPublisher<MessagePayloadType extends object>
 
       const topicName =
         this.locatorConfig?.topicName ?? this.creationConfig?.topic?.Name ?? 'unknown'
-      this.handleMessageProcessed(
-        parsedMessage,
-        'published',
+      this.handleMessageProcessed({
+        message: parsedMessage,
+        processingResult: 'published',
         messageProcessingStartTimestamp,
-        topicName,
-      )
+        queueName: topicName,
+      })
     } catch (error) {
       const err = error as Error
       this.handleError(err)

--- a/packages/sns/lib/sns/AbstractSnsPublisher.ts
+++ b/packages/sns/lib/sns/AbstractSnsPublisher.ts
@@ -61,6 +61,7 @@ export abstract class AbstractSnsPublisher<MessagePayloadType extends object>
     }
 
     try {
+      const messageProcessingStartTimestamp = Date.now()
       const parsedMessage = messageSchemaResult.result.parse(message)
 
       if (this.logMessages) {
@@ -76,7 +77,15 @@ export abstract class AbstractSnsPublisher<MessagePayloadType extends object>
       )
 
       await this.sendMessage(maybeOffloadedPayloadMessage, options)
-      this.handleMessageProcessed(parsedMessage, 'published')
+
+      const topicName =
+        this.locatorConfig?.topicName ?? this.creationConfig?.topic?.Name ?? 'unknown'
+      this.handleMessageProcessed(
+        parsedMessage,
+        'published',
+        messageProcessingStartTimestamp,
+        topicName,
+      )
     } catch (error) {
       const err = error as Error
       this.handleError(err)

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sns",
-  "version": "19.1.0",
+  "version": "20.0.0",
   "private": false,
   "license": "MIT",
   "description": "SNS adapter for message-queue-toolkit",
@@ -33,9 +33,9 @@
     "@aws-sdk/client-sns": "^3.632.0",
     "@aws-sdk/client-sqs": "^3.632.0",
     "@aws-sdk/client-sts": "^3.632.0",
-    "@message-queue-toolkit/core": ">=18.1.0",
+    "@message-queue-toolkit/core": ">=19.0.0",
     "@message-queue-toolkit/schemas": ">=2.0.0",
-    "@message-queue-toolkit/sqs": "^18.1.0"
+    "@message-queue-toolkit/sqs": ">=19.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.670.0",

--- a/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
@@ -217,13 +217,13 @@ export abstract class AbstractSqsConsumer<
           await this.failProcessing(message)
 
           const messageId = this.tryToExtractId(message)
-          this.handleMessageProcessed(
-            null,
-            'invalid_message',
+          this.handleMessageProcessed({
+            message: null,
+            processingResult: 'invalid_message',
             messageProcessingStartTimestamp,
-            this.queueName,
-            messageId.result,
-          )
+            queueName: this.queueName,
+            messageId: messageId.result,
+          })
           return
         }
         const { parsedMessage, originalMessage } = deserializedMessage.result
@@ -255,12 +255,12 @@ export abstract class AbstractSqsConsumer<
 
         // success
         if (result.result) {
-          this.handleMessageProcessed(
-            originalMessage,
-            'consumed',
+          this.handleMessageProcessed({
+            message: originalMessage,
+            processingResult: 'consumed',
             messageProcessingStartTimestamp,
-            this.queueName,
-          )
+            queueName: this.queueName,
+          })
           return message
         }
 
@@ -273,31 +273,31 @@ export abstract class AbstractSqsConsumer<
                 MessageBody: JSON.stringify(this.updateInternalProperties(originalMessage)),
               }),
             )
-            this.handleMessageProcessed(
-              parsedMessage,
-              'retryLater',
+            this.handleMessageProcessed({
+              message: parsedMessage,
+              processingResult: 'retryLater',
               messageProcessingStartTimestamp,
-              this.queueName,
-            )
+              queueName: this.queueName,
+            })
           } else {
             await this.failProcessing(message)
-            this.handleMessageProcessed(
-              parsedMessage,
-              'error',
+            this.handleMessageProcessed({
+              message: parsedMessage,
+              processingResult: 'error',
               messageProcessingStartTimestamp,
-              this.queueName,
-            )
+              queueName: this.queueName,
+            })
           }
 
           return message
         }
 
-        this.handleMessageProcessed(
-          parsedMessage,
-          'error',
+        this.handleMessageProcessed({
+          message: parsedMessage,
+          processingResult: 'error',
           messageProcessingStartTimestamp,
-          this.queueName,
-        )
+          queueName: this.queueName,
+        })
         return Promise.reject(result.error)
       },
     })

--- a/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
@@ -210,12 +210,20 @@ export abstract class AbstractSqsConsumer<
       handleMessage: async (message: SQSMessage) => {
         if (message === null) return
 
+        const messageProcessingStartTimestamp = Date.now()
+
         const deserializedMessage = await this.deserializeMessage(message)
         if (deserializedMessage.error === 'abort') {
           await this.failProcessing(message)
 
           const messageId = this.tryToExtractId(message)
-          this.handleMessageProcessed(null, 'invalid_message', messageId.result)
+          this.handleMessageProcessed(
+            null,
+            'invalid_message',
+            messageProcessingStartTimestamp,
+            this.queueName,
+            messageId.result,
+          )
           return
         }
         const { parsedMessage, originalMessage } = deserializedMessage.result
@@ -247,7 +255,12 @@ export abstract class AbstractSqsConsumer<
 
         // success
         if (result.result) {
-          this.handleMessageProcessed(originalMessage, 'consumed')
+          this.handleMessageProcessed(
+            originalMessage,
+            'consumed',
+            messageProcessingStartTimestamp,
+            this.queueName,
+          )
           return message
         }
 
@@ -260,16 +273,31 @@ export abstract class AbstractSqsConsumer<
                 MessageBody: JSON.stringify(this.updateInternalProperties(originalMessage)),
               }),
             )
-            this.handleMessageProcessed(parsedMessage, 'retryLater')
+            this.handleMessageProcessed(
+              parsedMessage,
+              'retryLater',
+              messageProcessingStartTimestamp,
+              this.queueName,
+            )
           } else {
             await this.failProcessing(message)
-            this.handleMessageProcessed(parsedMessage, 'error')
+            this.handleMessageProcessed(
+              parsedMessage,
+              'error',
+              messageProcessingStartTimestamp,
+              this.queueName,
+            )
           }
 
           return message
         }
 
-        this.handleMessageProcessed(parsedMessage, 'error')
+        this.handleMessageProcessed(
+          parsedMessage,
+          'error',
+          messageProcessingStartTimestamp,
+          this.queueName,
+        )
         return Promise.reject(result.error)
       },
     })

--- a/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
@@ -78,12 +78,12 @@ export abstract class AbstractSqsPublisher<MessagePayloadType extends object>
       )
 
       await this.sendMessage(maybeOffloadedPayloadMessage, options)
-      this.handleMessageProcessed(
-        parsedMessage,
-        'published',
+      this.handleMessageProcessed({
+        message: parsedMessage,
+        processingResult: 'published',
         messageProcessingStartTimestamp,
-        this.queueName,
-      )
+        queueName: this.queueName,
+      })
     } catch (error) {
       const err = error as Error
       this.handleError(err)

--- a/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
@@ -62,6 +62,7 @@ export abstract class AbstractSqsPublisher<MessagePayloadType extends object>
     }
 
     try {
+      const messageProcessingStartTimestamp = Date.now()
       const parsedMessage = messageSchemaResult.result.parse(message)
 
       if (this.logMessages) {
@@ -77,7 +78,12 @@ export abstract class AbstractSqsPublisher<MessagePayloadType extends object>
       )
 
       await this.sendMessage(maybeOffloadedPayloadMessage, options)
-      this.handleMessageProcessed(parsedMessage, 'published')
+      this.handleMessageProcessed(
+        parsedMessage,
+        'published',
+        messageProcessingStartTimestamp,
+        this.queueName,
+      )
     } catch (error) {
       const err = error as Error
       this.handleError(err)

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sqs",
-  "version": "18.1.0",
+  "version": "19.0.0",
   "private": false,
   "license": "MIT",
   "description": "SQS adapter for message-queue-toolkit",
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-sqs": "^3.632.0",
-    "@message-queue-toolkit/core": ">=18.1.0"
+    "@message-queue-toolkit/core": ">=19.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.670.0",

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
@@ -369,6 +369,7 @@ describe('SqsPermissionConsumer', () => {
           messageType: 'add',
           processingResult: 'consumed',
           messageProcessingMilliseconds: expect.any(Number),
+          queueName: SqsPermissionConsumer.QUEUE_NAME,
           message: expect.objectContaining({
             id: '1',
             messageType: 'add',

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
@@ -368,7 +368,9 @@ describe('SqsPermissionConsumer', () => {
           messageId: '1',
           messageType: 'add',
           processingResult: 'consumed',
-          messageProcessingMilliseconds: expect.any(Number),
+          messageTimestamp: expect.any(Number),
+          messageProcessingStartTimestamp: expect.any(Number),
+          messageProcessingEndTimestamp: expect.any(Number),
           queueName: SqsPermissionConsumer.QUEUE_NAME,
           message: expect.objectContaining({
             id: '1',


### PR DESCRIPTION
After analysing first message processing metrics results, the following improvements were identified:

- processing time measurement - currently it operates on message timestamp. It means that if message waits in the queue, or is hold by the barrier, that waiting time is included in the measurement. While this is useful metric, we should also measure processing time itself. 
- Prometheus metric labels:
  - processingResult - most important, that will allow to monitor `published`, `consumed` , `retryLater` statuses separately, currently there are indistinguishable
  - queueName - that will allow us to filter measurements by specific queue
  
See `UPGRADING.md` for the description of changes