### PR TITLE
Add missing handlerSpy for AMQP publisher

### DIFF
--- a/packages/amqp/lib/AbstractAmqpQueuePublisher.ts
+++ b/packages/amqp/lib/AbstractAmqpQueuePublisher.ts
@@ -50,6 +50,10 @@ export abstract class AbstractAmqpQueuePublisher<
     super.publish(message, options)
   }
 
+  protected override resolveTopicOrQueue(): string {
+    return this.queueName
+  }
+
   protected override createMissingEntities(): Promise<void> {
     return ensureAmqpQueue(this.connection!, this.channel, this.creationConfig, this.locatorConfig)
   }

--- a/packages/amqp/lib/AbstractAmqpTopicPublisher.ts
+++ b/packages/amqp/lib/AbstractAmqpTopicPublisher.ts
@@ -52,6 +52,10 @@ export abstract class AbstractAmqpTopicPublisher<
     this.channel.publish(this.exchange!, options.routingKey, message, options.publishOptions)
   }
 
+  protected override resolveTopicOrQueue(): string {
+    return this.exchange!
+  }
+
   protected override async createMissingEntities(): Promise<void> {
     await ensureExchange(this.connection!, this.channel, this.creationConfig, this.locatorConfig)
   }

--- a/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
+++ b/packages/amqp/test/consumers/AmqpPermissionConsumer.spec.ts
@@ -96,7 +96,7 @@ describe('AmqpPermissionConsumer', () => {
 
       await newConsumer.close()
 
-      expect(logger.loggedMessages.length).toBe(5)
+      expect(logger.loggedMessages.length).toBe(6)
       expect(logger.loggedMessages).toMatchObject([
         'Propagating new connection across 0 receivers',
         {
@@ -104,6 +104,7 @@ describe('AmqpPermissionConsumer', () => {
           messageType: 'add',
         },
         'timestamp not defined, adding it automatically',
+        expect.any(Object),
         {
           id: '1',
           messageType: 'add',

--- a/packages/amqp/test/utils/testContext.ts
+++ b/packages/amqp/test/utils/testContext.ts
@@ -13,6 +13,7 @@ import { Lifetime, asClass, asFunction, createContainer } from 'awilix'
 import { AwilixManager } from 'awilix-manager'
 import { z } from 'zod'
 
+import pino from 'pino'
 import { AmqpConnectionManager } from '../../lib/AmqpConnectionManager'
 import type { AmqpAwareEventDefinition } from '../../lib/AmqpQueuePublisherManager'
 import { AmqpQueuePublisherManager } from '../../lib/AmqpQueuePublisherManager'
@@ -83,8 +84,7 @@ export const TestEvents = {
 export type TestEventsType = (typeof TestEvents)[keyof typeof TestEvents][]
 export type TestEventPublishPayloadsType = z.infer<TestEventsType[number]['publisherSchema']>
 
-// @ts-ignore
-const TestLogger: CommonLogger = console
+const TestLogger: CommonLogger = pino()
 
 export async function registerDependencies(
   config: AmqpConfig,


### PR DESCRIPTION
Apparently it was missing all along 😿 