### PR TITLE
Added queueName to SQS locator config

### DIFF
--- a/packages/sns/lib/utils/snsInitter.ts
+++ b/packages/sns/lib/utils/snsInitter.ts
@@ -57,7 +57,7 @@ export async function initSnsSqs(
     }
 
     const topicResolutionOptions: TopicResolutionOptions = {
-      ...locatorConfig,
+      ...(locatorConfig as SNSSQSQueueLocatorType),
       ...creationConfig.topic,
     }
 

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sns",
-  "version": "21.0.1",
+  "version": "21.1.0",
   "private": false,
   "license": "MIT",
   "description": "SNS adapter for message-queue-toolkit",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sns",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "private": false,
   "license": "MIT",
   "description": "SNS adapter for message-queue-toolkit",
@@ -35,7 +35,7 @@
     "@aws-sdk/client-sts": "^3.632.0",
     "@message-queue-toolkit/core": ">=20.0.0",
     "@message-queue-toolkit/schemas": ">=2.0.0",
-    "@message-queue-toolkit/sqs": ">=20.0.0"
+    "@message-queue-toolkit/sqs": ">=20.0.1"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.670.0",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/client-sts": "^3.632.0",
     "@message-queue-toolkit/core": ">=20.0.0",
     "@message-queue-toolkit/schemas": ">=2.0.0",
-    "@message-queue-toolkit/sqs": ">=20.0.1"
+    "@message-queue-toolkit/sqs": ">=20.1.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.670.0",

--- a/packages/sqs/index.ts
+++ b/packages/sqs/index.ts
@@ -18,7 +18,13 @@ export {
 } from './lib/sqs/AbstractSqsPublisher'
 export type { SQSMessageOptions } from './lib/sqs/AbstractSqsPublisher'
 
-export { assertQueue, deleteQueue, getQueueAttributes, getQueueUrl } from './lib/utils/sqsUtils'
+export {
+  assertQueue,
+  deleteQueue,
+  getQueueAttributes,
+  getQueueUrl,
+  resolveQueueUrlFromLocatorConfig,
+} from './lib/utils/sqsUtils'
 export { deleteSqs, updateQueueAttributes } from './lib/utils/sqsInitter'
 export { deserializeSQSMessage } from './lib/utils/sqsMessageDeserializer'
 export {

--- a/packages/sqs/lib/sqs/AbstractSqsService.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsService.ts
@@ -24,7 +24,8 @@ export type SQSCreationConfig = {
 } & ExtraSQSCreationParams
 
 export type SQSQueueLocatorType = {
-  queueUrl: string
+  queueUrl?: string
+  queueName?: string
 }
 
 export abstract class AbstractSqsService<

--- a/packages/sqs/lib/sqs/AbstractSqsService.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsService.ts
@@ -23,10 +23,15 @@ export type SQSCreationConfig = {
   forceTagUpdate?: boolean
 } & ExtraSQSCreationParams
 
-export type SQSQueueLocatorType = {
-  queueUrl?: string
-  queueName?: string
-}
+export type SQSQueueLocatorType =
+  | {
+      queueUrl: string
+      queueName?: never
+    }
+  | {
+      queueName: string
+      queueUrl?: never
+    }
 
 export abstract class AbstractSqsService<
   MessagePayloadType extends object,

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sqs",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "private": false,
   "license": "MIT",
   "description": "SQS adapter for message-queue-toolkit",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@message-queue-toolkit/sqs",
-  "version": "20.0.1",
+  "version": "20.1.0",
   "private": false,
   "license": "MIT",
   "description": "SQS adapter for message-queue-toolkit",

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.spec.ts
@@ -26,6 +26,7 @@ import type { PERMISSIONS_ADD_MESSAGE_TYPE } from './userConsumerSchemas'
 describe('SqsPermissionConsumer', () => {
   describe('init', () => {
     const queueName = 'myTestQueue'
+    const queueUrl = `http://sqs.eu-west-1.localstack:4566/000000000000/${queueName}`
 
     let diContainer: AwilixContainer<Dependencies>
     let sqsClient: SQSClient
@@ -44,7 +45,7 @@ describe('SqsPermissionConsumer', () => {
     it('throws an error when invalid queue locator is passed', async () => {
       const newConsumer = new SqsPermissionConsumer(diContainer.cradle, {
         locatorConfig: {
-          queueUrl: `http://s3.localhost.localstack.cloud:4566/000000000000/${queueName}`,
+          queueUrl,
         },
       })
 
@@ -58,14 +59,27 @@ describe('SqsPermissionConsumer', () => {
 
       const newConsumer = new SqsPermissionConsumer(diContainer.cradle, {
         locatorConfig: {
-          queueUrl: `http://s3.localhost.localstack.cloud:4566/000000000000/${queueName}`,
+          queueUrl,
         },
       })
 
       await newConsumer.init()
-      expect(newConsumer.queueProps.url).toBe(
-        `http://s3.localhost.localstack.cloud:4566/000000000000/${queueName}`,
-      )
+      expect(newConsumer.queueProps.url).toBe(queueUrl)
+    })
+
+    it('resolves existing queue by name', async () => {
+      await assertQueue(sqsClient, {
+        QueueName: queueName,
+      })
+
+      const newConsumer = new SqsPermissionConsumer(diContainer.cradle, {
+        locatorConfig: {
+          queueName,
+        },
+      })
+
+      await newConsumer.init()
+      expect(newConsumer.queueProps.url).toBe(queueUrl)
     })
 
     describe('attributes update', () => {
@@ -97,9 +111,7 @@ describe('SqsPermissionConsumer', () => {
         const sqsSpy = vi.spyOn(sqsClient, 'send')
 
         await newConsumer.init()
-        expect(newConsumer.queueProps.url).toBe(
-          `http://sqs.eu-west-1.localstack:4566/000000000000/${queueName}`,
-        )
+        expect(newConsumer.queueProps.url).toBe(queueUrl)
 
         const updateCall = sqsSpy.mock.calls.find((entry) => {
           return entry[0].constructor.name === 'SetQueueAttributesCommand'
@@ -141,9 +153,7 @@ describe('SqsPermissionConsumer', () => {
         const sqsSpy = vi.spyOn(sqsClient, 'send')
 
         await newConsumer.init()
-        expect(newConsumer.queueProps.url).toBe(
-          `http://sqs.eu-west-1.localstack:4566/000000000000/${queueName}`,
-        )
+        expect(newConsumer.queueProps.url).toBe(queueUrl)
 
         const updateCall = sqsSpy.mock.calls.find((entry) => {
           return entry[0].constructor.name === 'SetQueueAttributesCommand'
@@ -196,9 +206,7 @@ describe('SqsPermissionConsumer', () => {
         const sqsSpy = vi.spyOn(sqsClient, 'send')
 
         await newConsumer.init()
-        expect(newConsumer.queueProps.url).toBe(
-          `http://sqs.eu-west-1.localstack:4566/000000000000/${queueName}`,
-        )
+        expect(newConsumer.queueProps.url).toBe(queueUrl)
 
         const updateCall = sqsSpy.mock.calls.find((entry) => {
           return entry[0].constructor.name === 'TagQueueCommand'
@@ -248,9 +256,7 @@ describe('SqsPermissionConsumer', () => {
         const sqsSpy = vi.spyOn(sqsClient, 'send')
 
         await newConsumer.init()
-        expect(newConsumer.queueProps.url).toBe(
-          `http://sqs.eu-west-1.localstack:4566/000000000000/${queueName}`,
-        )
+        expect(newConsumer.queueProps.url).toBe(queueUrl)
 
         const updateCall = sqsSpy.mock.calls.find((entry) => {
           return entry[0].constructor.name === 'TagQueueCommand'


### PR DESCRIPTION
Providing `queueUrl` in the locator config is not always convenient, as it requires users to provide AWS connection details. This PR introduces `queueName` parameter for locator config, that can be provided instead. The corresponding queueUrl is then resolved dynamically.