### PR TITLE
Automatically init non-lazy publishers on PublisherManager creation

### DIFF
--- a/packages/amqp/README.md
+++ b/packages/amqp/README.md
@@ -71,4 +71,4 @@ publisher.publish(message)
 
 By default `message-queue-toolkit/amqp` will lazily instantiate publishers before the publish in case they weren't instantiated before. This may result in system not failing fast when connection to AMQP cannot be established, as instantiation happens asynchronously. In case that is an undesirable behaviour, you can set parameter `isLazyInitEnabled` to false either directly for a publisher, or as one of the `newPublisherOptions` parameters for the `AmqpQueuePublisherManager`.
 
-In case when lazy instantiation is disabled, queues should be initilized explicitly by using an async `AmqpQueuePublisherManager::initRegisteredQueues()` method.
+In case when lazy instantiation is disabled, queues should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredQueues()` method.

--- a/packages/amqp/README.md
+++ b/packages/amqp/README.md
@@ -71,4 +71,4 @@ publisher.publish(message)
 
 By default `message-queue-toolkit/amqp` will lazily instantiate publishers before the publish in case they weren't instantiated before. This may result in system not failing fast when connection to AMQP cannot be established, as instantiation happens asynchronously. In case that is an undesirable behaviour, you can set parameter `isLazyInitEnabled` to false either directly for a publisher, or as one of the `newPublisherOptions` parameters for the `AmqpQueuePublisherManager`.
 
-In case when lazy instantiation is disabled, publishers should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredPublishers()` method.
+In case when lazy instantiation is disabled, publishers should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredPublishers()` method. It also has an optional `publishers?: string[]` argument, which can be used to only initialize some specific publishers.

--- a/packages/amqp/README.md
+++ b/packages/amqp/README.md
@@ -70,3 +70,5 @@ publisher.publish(message)
 ## Lazy instantiation
 
 By default `message-queue-toolkit/amqp` will lazily instantiate publishers before the publish in case they weren't instantiated before. This may result in system not failing fast when connection to AMQP cannot be established, as instantiation happens asynchronously. In case that is an undesirable behaviour, you can set parameter `isLazyInitEnabled` to false either directly for a publisher, or as one of the `newPublisherOptions` parameters for the `AmqpQueuePublisherManager`.
+
+In case when lazy instantiation is disabled, queues should be initilized explicitly by using an async `AmqpQueuePublisherManager::initRegisteredQueues()` method.

--- a/packages/amqp/README.md
+++ b/packages/amqp/README.md
@@ -71,4 +71,4 @@ publisher.publish(message)
 
 By default `message-queue-toolkit/amqp` will lazily instantiate publishers before the publish in case they weren't instantiated before. This may result in system not failing fast when connection to AMQP cannot be established, as instantiation happens asynchronously. In case that is an undesirable behaviour, you can set parameter `isLazyInitEnabled` to false either directly for a publisher, or as one of the `newPublisherOptions` parameters for the `AmqpQueuePublisherManager`.
 
-In case when lazy instantiation is disabled, publishers should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredQueues()` method.
+In case when lazy instantiation is disabled, publishers should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredPublishers()` method.

--- a/packages/amqp/README.md
+++ b/packages/amqp/README.md
@@ -71,4 +71,4 @@ publisher.publish(message)
 
 By default `message-queue-toolkit/amqp` will lazily instantiate publishers before the publish in case they weren't instantiated before. This may result in system not failing fast when connection to AMQP cannot be established, as instantiation happens asynchronously. In case that is an undesirable behaviour, you can set parameter `isLazyInitEnabled` to false either directly for a publisher, or as one of the `newPublisherOptions` parameters for the `AmqpQueuePublisherManager`.
 
-In case when lazy instantiation is disabled, publishers should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredPublishers()` method. It also has an optional `publishers?: string[]` argument, which can be used to only initialize some specific publishers.
+In case when lazy instantiation is disabled, publishers should be initialized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredPublishers()` method. It also has an optional `publishers?: string[]` argument, which can be used to only initialize some specific publishers.

--- a/packages/amqp/README.md
+++ b/packages/amqp/README.md
@@ -71,4 +71,4 @@ publisher.publish(message)
 
 By default `message-queue-toolkit/amqp` will lazily instantiate publishers before the publish in case they weren't instantiated before. This may result in system not failing fast when connection to AMQP cannot be established, as instantiation happens asynchronously. In case that is an undesirable behaviour, you can set parameter `isLazyInitEnabled` to false either directly for a publisher, or as one of the `newPublisherOptions` parameters for the `AmqpQueuePublisherManager`.
 
-In case when lazy instantiation is disabled, queues should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredQueues()` method.
+In case when lazy instantiation is disabled, publishers should be initilized explicitly by using an async `AmqpQueuePublisherManager.initRegisteredQueues()` method.

--- a/packages/amqp/lib/AbstractAmqpService.ts
+++ b/packages/amqp/lib/AbstractAmqpService.ts
@@ -136,6 +136,10 @@ export abstract class AbstractAmqpService<
   }
 
   public async init() {
+    if (this.isInitted) {
+      return
+    }
+
     if (this.creationConfig?.updateAttributesIfExists) {
       throw new Error(
         'updateAttributesIfExists parameter is not currently supported by the AMQP adapter',

--- a/packages/amqp/lib/AbstractAmqpService.ts
+++ b/packages/amqp/lib/AbstractAmqpService.ts
@@ -136,10 +136,6 @@ export abstract class AbstractAmqpService<
   }
 
   public async init() {
-    if (this.isInitted) {
-      return
-    }
-
     if (this.creationConfig?.updateAttributesIfExists) {
       throw new Error(
         'updateAttributesIfExists parameter is not currently supported by the AMQP adapter',

--- a/packages/amqp/lib/AmqpQueuePublisherManager.spec.ts
+++ b/packages/amqp/lib/AmqpQueuePublisherManager.spec.ts
@@ -83,12 +83,15 @@ describe('AmqpQueuePublisherManager', () => {
       const fakeConsumer = new FakeQueueConsumer(diContainer.cradle, TestEvents.updated)
       await fakeConsumer.start()
 
-      const publishedMessage = queuePublisherManagerNoLazy.publishSync(FakeQueueConsumer.QUEUE_NAME, {
-        type: 'entity.updated',
-        payload: {
-          updatedData: 'msg',
+      const publishedMessage = queuePublisherManagerNoLazy.publishSync(
+        FakeQueueConsumer.QUEUE_NAME,
+        {
+          type: 'entity.updated',
+          payload: {
+            updatedData: 'msg',
+          },
         },
-      })
+      )
 
       const result = await fakeConsumer.handlerSpy.waitForMessageWithId(publishedMessage.id)
 
@@ -96,7 +99,9 @@ describe('AmqpQueuePublisherManager', () => {
     })
 
     it('not publishes to the queue with lazy publisher, when it was not initialized', async () => {
-      await diContainer.cradle.queuePublisherManagerNoLazy.initRegisteredPublishers(['non-existing-name'])
+      await diContainer.cradle.queuePublisherManagerNoLazy.initRegisteredPublishers([
+        'non-existing-name',
+      ])
 
       const { queuePublisherManagerNoLazy } = diContainer.cradle
       const fakeConsumer = new FakeQueueConsumer(diContainer.cradle, TestEvents.updated)

--- a/packages/amqp/lib/AmqpQueuePublisherManager.spec.ts
+++ b/packages/amqp/lib/AmqpQueuePublisherManager.spec.ts
@@ -1,5 +1,5 @@
 import type { AwilixContainer } from 'awilix'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { FakeQueueConsumer } from '../test/fakes/FakeQueueConsumer'
 import { TEST_AMQP_CONFIG } from '../test/utils/testAmqpConfig'
@@ -9,8 +9,15 @@ import type { Dependencies } from '../test/utils/testContext'
 describe('AmqpQueuePublisherManager', () => {
   describe('publish', () => {
     let diContainer: AwilixContainer<Dependencies>
-    beforeAll(async () => {
+
+    beforeEach(async () => {
       diContainer = await registerDependencies(TEST_AMQP_CONFIG)
+    })
+
+    afterEach(async () => {
+      const { awilixManager } = diContainer.cradle
+      await awilixManager.executeDispose()
+      await diContainer.dispose()
     })
 
     it('publishes to the correct queue', async () => {

--- a/packages/amqp/lib/AmqpQueuePublisherManager.ts
+++ b/packages/amqp/lib/AmqpQueuePublisherManager.ts
@@ -67,7 +67,6 @@ export type AmqpMessageSchemaType<T extends AmqpAwareEventDefinition> = z.infer<
   T['publisherSchema']
 >
 
-
 export class AmqpQueuePublisherManager<
   T extends AbstractAmqpQueuePublisher<
     z.infer<SupportedEventDefinitions[number]['publisherSchema']>

--- a/packages/amqp/lib/AmqpQueuePublisherManager.ts
+++ b/packages/amqp/lib/AmqpQueuePublisherManager.ts
@@ -132,9 +132,13 @@ export class AmqpQueuePublisherManager<
     }
   }
 
-  async initRegisteredQueues(): Promise<void> {
+  async initRegisteredPublishers(publishers?: string[]): Promise<void> {
     for (const eventTarget in this.targetToPublisherMap) {
       const queueName = eventTarget as NonNullable<SupportedEventDefinitions[number]['queueName']>
+
+      if (publishers?.length && !publishers.includes(queueName)) {
+        continue
+      }
 
       await this.targetToPublisherMap[queueName].init()
     }

--- a/packages/amqp/lib/AmqpQueuePublisherManager.ts
+++ b/packages/amqp/lib/AmqpQueuePublisherManager.ts
@@ -120,10 +120,6 @@ export class AmqpQueuePublisherManager<
       },
       publisherFactory: options.publisherFactory ?? new CommonAmqpQueuePublisherFactory(),
     })
-
-    if (!options.newPublisherOptions.isLazyInitEnabled) {
-      this.initRegisteredQueues()
-    }
   }
 
   protected override resolveCreationConfig(
@@ -136,13 +132,11 @@ export class AmqpQueuePublisherManager<
     }
   }
 
-  protected initRegisteredQueues(): void {
-    for (const eventTarget in this.targetToEventMap) {
+  async initRegisteredQueues(): Promise<void> {
+    for (const eventTarget in this.targetToPublisherMap) {
       const queueName = eventTarget as NonNullable<SupportedEventDefinitions[number]['queueName']>
 
-      if (this.targetToPublisherMap[queueName]) {
-        this.targetToPublisherMap[queueName].init()
-      }
+      await this.targetToPublisherMap[queueName].init()
     }
   }
 

--- a/packages/amqp/lib/AmqpQueuePublisherManager.ts
+++ b/packages/amqp/lib/AmqpQueuePublisherManager.ts
@@ -67,6 +67,7 @@ export type AmqpMessageSchemaType<T extends AmqpAwareEventDefinition> = z.infer<
   T['publisherSchema']
 >
 
+
 export class AmqpQueuePublisherManager<
   T extends AbstractAmqpQueuePublisher<
     z.infer<SupportedEventDefinitions[number]['publisherSchema']>
@@ -120,6 +121,10 @@ export class AmqpQueuePublisherManager<
       },
       publisherFactory: options.publisherFactory ?? new CommonAmqpQueuePublisherFactory(),
     })
+
+    if (!options.newPublisherOptions.isLazyInitEnabled) {
+      this.initRegisteredQueues()
+    }
   }
 
   protected override resolveCreationConfig(
@@ -129,6 +134,16 @@ export class AmqpQueuePublisherManager<
       ...this.newPublisherOptions,
       queueOptions: {},
       queueName,
+    }
+  }
+
+  protected initRegisteredQueues(): void {
+    for (const eventTarget in this.targetToEventMap) {
+      const queueName = eventTarget as NonNullable<SupportedEventDefinitions[number]['queueName']>
+
+      if (this.targetToPublisherMap[queueName]) {
+        this.targetToPublisherMap[queueName].init()
+      }
     }
   }
 


### PR DESCRIPTION
After introducing option to disable lazy init for queues, there's no way to actually initialise them.
This PR introduces automatic initialisation of registered queues when lazy init is disabled, at the moment when PublisherManager is created.