### PR TITLE
Kafka handling non json messages successfully

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     restart: on-failure
 
   kafka:
-    image: apache/kafka:latest
+    image: apache/kafka:3.7.1
     container_name: kafka
     ports:
       - 9092:9092

--- a/packages/kafka/lib/utils/safeJsonDeserializer.spec.ts
+++ b/packages/kafka/lib/utils/safeJsonDeserializer.spec.ts
@@ -1,0 +1,38 @@
+import { stringValueSerializer } from '@lokalise/node-core'
+import { safeJsonDeserializer } from './safeJsonDeserializer.js'
+
+describe('safeJsonDeserializer', () => {
+  it('should deserialize valid JSON strings', () => {
+    const validJson = JSON.stringify({ key: 'value' })
+    const result = safeJsonDeserializer(validJson)
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('should return undefined for invalid JSON strings', () => {
+    const invalidJson = stringValueSerializer({ key: 'value' })
+    const result = safeJsonDeserializer(invalidJson)
+    expect(result).toBeUndefined()
+  })
+
+  it('should deserialize for valid buffer inputs', () => {
+    const buffer = Buffer.from(JSON.stringify({ key: 'value' }))
+    const result = safeJsonDeserializer(buffer)
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('should return undefined for invalid buffer inputs', () => {
+    const invalidBuffer = Buffer.from('invalid json')
+    const result = safeJsonDeserializer(invalidBuffer)
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined for invalid inputs', () => {
+    const result = safeJsonDeserializer(1 as any)
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined for undefined inputs', () => {
+    const result = safeJsonDeserializer(undefined)
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/kafka/lib/utils/safeJsonDeserializer.ts
+++ b/packages/kafka/lib/utils/safeJsonDeserializer.ts
@@ -1,0 +1,11 @@
+export const safeJsonDeserializer = (data?: string | Buffer): object | undefined => {
+  if (!data) return undefined
+  // Checking to be safe
+  if (!Buffer.isBuffer(data) && typeof data !== 'string') return undefined
+
+  try {
+    return JSON.parse(data.toString('utf-8'))
+  } catch (_) {
+    return undefined
+  }
+}

--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@message-queue-toolkit/kafka",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "engines": {
         "node": ">= 22.14.0"
     },

--- a/packages/kafka/test/consumer/PermissionConsumer.spec.ts
+++ b/packages/kafka/test/consumer/PermissionConsumer.spec.ts
@@ -268,6 +268,8 @@ describe('PermissionConsumer', () => {
       // Then
       await waitAndRetry(() => errorSpy.mock.calls.length > 0, 10, 100)
       expect(errorSpy).not.toHaveBeenCalled()
+
+      await producer.close()
     })
   })
 

--- a/packages/kafka/test/utils/testContext.ts
+++ b/packages/kafka/test/utils/testContext.ts
@@ -73,6 +73,7 @@ const resolveDIConfig = (awilixManager: AwilixManager): DiConfig => ({
       ({
         report: () => {},
       }) satisfies ErrorReporter,
+    SINGLETON_CONFIG,
   ),
   transactionObservabilityManager: asFunction(
     () =>


### PR DESCRIPTION
Sometimes I see errors coming from `JSON.parse`, for some reason we are receiving non-json events from DB, we should ignore those messages and not fail