### PR TITLE
EXP-590 Waiting message in queue metric

### DIFF
--- a/packages/metrics/lib/index.ts
+++ b/packages/metrics/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './prometheus/metrics/message-time/PrometheusMessageTimeMetric.ts'
 export * from './prometheus/metrics/message-time/PrometheusMessageLifetimeMetric.ts'
 export * from './prometheus/metrics/message-time/PrometheusMessageProcessingTimeMetric.ts'
 export * from './prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.ts'

--- a/packages/metrics/lib/index.ts
+++ b/packages/metrics/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './prometheus/metrics/message-time/PrometheusMessageLifetimeMetric.ts'
 export * from './prometheus/metrics/message-time/PrometheusMessageProcessingTimeMetric.ts'
+export * from './prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.ts'
 export * from './prometheus/metrics/message-error/PrometheusMessageErrorCounter.ts'
 export * from './prometheus/PrometheusMessageMetric.ts'
 export * from './prometheus/types.ts'

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageLifetimeMetric.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageLifetimeMetric.ts
@@ -7,9 +7,8 @@ export class PrometheusMessageLifetimeMetric<
   protected calculateObservedValue(
     metadata: ProcessedMessageMetadata<MessagePayload>,
   ): number | null {
-    if (!metadata.messageTimestamp) {
-      return null
-    }
+    if (!metadata.messageTimestamp) return null
+
     return metadata.messageProcessingEndTimestamp - metadata.messageTimestamp
   }
 }

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.spec.ts
@@ -1,0 +1,238 @@
+import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
+import * as promClient from 'prom-client'
+import type { Histogram } from 'prom-client'
+import { describe, expect, it, vi } from 'vitest'
+import { PrometheusMessageQueueTimeMetric } from './PrometheusMessageQueueTimeMetric.js'
+
+type TestMessage = {
+  id: string
+  messageType: 'test'
+  timestamp?: string
+  metadata?: {
+    schemaVersion: string
+  }
+}
+
+describe('PrometheusMessageQueueTimeMetric', () => {
+  it('creates and uses Histogram metric properly', () => {
+    // Given
+    const registeredMessages: ProcessedMessageMetadata<TestMessage>[] = []
+    const metric = new PrometheusMessageQueueTimeMetric<TestMessage>(
+      {
+        name: 'test_metric',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+        messageVersion: (metadata: ProcessedMessageMetadata<TestMessage>) => {
+          registeredMessages.push(metadata) // Mocking it to check if value is registered properly
+          return undefined
+        },
+      },
+      promClient,
+    )
+
+    // When
+    const messages: TestMessage[] = [
+      {
+        id: '1',
+        messageType: 'test',
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: '2',
+        messageType: 'test',
+        timestamp: new Date().toISOString(),
+        metadata: {
+          schemaVersion: '1.0.0',
+        },
+      },
+    ]
+
+    const timestamp = Date.now()
+    const processedMessageMetadataEntries: ProcessedMessageMetadata<TestMessage>[] = messages.map(
+      (message) => ({
+        messageId: message.id,
+        messageType: message.messageType,
+        processingResult: { status: 'consumed' },
+        message: message,
+        queueName: 'test-queue',
+        messageTimestamp: timestamp,
+        messageProcessingStartTimestamp: timestamp,
+        messageProcessingEndTimestamp: timestamp + 102,
+      }),
+    )
+
+    for (const processedMessageMetadata of processedMessageMetadataEntries) {
+      metric.registerProcessedMessage(processedMessageMetadata)
+    }
+
+    // Then
+    expect(registeredMessages).toStrictEqual(processedMessageMetadataEntries)
+  })
+
+  it('skips message if messageTimestamp is not available', () => {
+    // Given
+    const observedValues: { labels: Record<string, any>; value: number }[] = []
+    vi.spyOn(promClient.register, 'getSingleMetric').mockReturnValue({
+      observe(labels: Record<string, string | number>, value: number) {
+        observedValues.push({ labels, value })
+      },
+    } as Histogram)
+
+    const metric = new PrometheusMessageQueueTimeMetric<TestMessage>(
+      {
+        name: 'Test metric',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+      },
+      promClient,
+    )
+
+    // When
+    const message: TestMessage = {
+      id: '1',
+      messageType: 'test',
+      timestamp: new Date().toISOString(),
+    }
+
+    const timestamp = Date.now()
+    metric.registerProcessedMessage({
+      messageId: message.id,
+      messageType: message.messageType,
+      processingResult: { status: 'consumed' },
+      message: message,
+      queueName: 'test-queue',
+      messageTimestamp: undefined,
+      messageProcessingStartTimestamp: timestamp,
+      messageProcessingEndTimestamp: timestamp,
+    })
+
+    // Then
+    expect(observedValues).toStrictEqual([])
+  })
+
+  it('registers values properly', () => {
+    // Given
+    const observedValues: { labels: Record<string, any>; value: number }[] = []
+    vi.spyOn(promClient.register, 'getSingleMetric').mockReturnValue({
+      observe(labels: Record<string, string | number>, value: number) {
+        observedValues.push({ labels, value })
+      },
+    } as Histogram)
+
+    const metric = new PrometheusMessageQueueTimeMetric<TestMessage>(
+      {
+        name: 'Test metric',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+      },
+      promClient,
+    )
+
+    // When
+    const message: TestMessage = {
+      id: '1',
+      messageType: 'test',
+      timestamp: new Date().toISOString(),
+    }
+
+    const timestamp = Date.now()
+    metric.registerProcessedMessage({
+      messageId: message.id,
+      messageType: message.messageType,
+      processingResult: { status: 'consumed' },
+      message: message,
+      queueName: 'test-queue',
+      messageTimestamp: timestamp,
+      messageProcessingStartTimestamp: timestamp + 102,
+      messageProcessingEndTimestamp: timestamp,
+    })
+
+    // Then
+    expect(observedValues).toStrictEqual([
+      {
+        labels: {
+          messageType: 'test',
+          version: undefined,
+          result: 'consumed',
+          queue: 'test-queue',
+        },
+        value: 102,
+      },
+    ])
+  })
+
+  it('resolves version properly', () => {
+    // Given
+    const observedValues: { labels: Record<string, any>; value: number }[] = []
+    vi.spyOn(promClient.register, 'getSingleMetric').mockReturnValue({
+      observe(labels: Record<string, string | number>, value: number) {
+        observedValues.push({ labels, value })
+      },
+    } as Histogram)
+
+    const metric = new PrometheusMessageQueueTimeMetric<TestMessage>(
+      {
+        name: 'Test metric',
+        helpDescription: 'test description',
+        buckets: [1, 2, 3],
+        messageVersion: (metadata: ProcessedMessageMetadata<TestMessage>) =>
+          metadata.message?.metadata?.schemaVersion,
+      },
+      promClient,
+    )
+
+    // When
+    const queueName = 'test-queue'
+    const messages: TestMessage[] = [
+      {
+        id: '1',
+        messageType: 'test',
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: '2',
+        messageType: 'test',
+        timestamp: new Date().toISOString(),
+        metadata: {
+          schemaVersion: '1.0.0',
+        },
+      },
+    ]
+
+    for (const message of messages) {
+      const timestamp = Date.now()
+      metric.registerProcessedMessage({
+        messageId: message.id,
+        messageType: message.messageType,
+        processingResult: { status: 'consumed' },
+        message: message,
+        queueName,
+        messageTimestamp: Date.now(),
+        messageProcessingStartTimestamp: timestamp + 53,
+        messageProcessingEndTimestamp: timestamp,
+      })
+    }
+
+    // Then
+    expect(observedValues).toStrictEqual([
+      {
+        labels: {
+          messageType: 'test',
+          version: undefined,
+          result: 'consumed',
+          queue: queueName,
+        },
+        value: 53,
+      },
+      {
+        labels: {
+          messageType: 'test',
+          version: '1.0.0',
+          result: 'consumed',
+          queue: queueName,
+        },
+        value: 53,
+      },
+    ])
+  })
+})

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.ts
@@ -1,0 +1,16 @@
+import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
+import { PrometheusMessageTimeMetric } from './PrometheusMessageTimeMetric.ts'
+
+/**
+ * This metric measures the time a message spends in the queue before processing starts.
+ */
+export class PrometheusMessageQueueTimeMetric<
+  MessagePayload extends object,
+> extends PrometheusMessageTimeMetric<MessagePayload> {
+  protected calculateObservedValue(
+    metadata: ProcessedMessageMetadata<MessagePayload>,
+  ): number | null {
+    if (!metadata.messageTimestamp) return null
+    return metadata.messageProcessingStartTimestamp - metadata.messageTimestamp
+  }
+}

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@message-queue-toolkit/metrics",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "private": false,
     "license": "MIT",
     "description": "Utilities for collecting metrics in message-queue-toolkit",


### PR DESCRIPTION
Adding `PrometheusMessageQueueTimeMetric` to facilitate measuring the time that a message was waiting in the queue