### PR TITLE
chore: platformatic kafka update

### DIFF
--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -53,7 +53,7 @@
     "dependencies": {
         "@lokalise/node-core": "^14.2.0",
         "@lokalise/universal-ts-utils": "^4.5.1",
-        "@platformatic/kafka": "^1.11.0"
+        "@platformatic/kafka": "^1.12.0"
     },
     "peerDependencies": {
         "@message-queue-toolkit/core": ">=23.0.0",

--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@message-queue-toolkit/kafka",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "engines": {
         "node": ">= 22.14.0"
     },


### PR DESCRIPTION
With the new Platformatic Kafka, we can already use AWS token-based auth. Now, it is possible to provide a method to generate a token in case renewal is needed so we should be able to use it.

More details here -> https://github.com/platformatic/kafka/releases/tag/v1.12.0

As this library is reusing types and passing options directly, we only need to update the version to allow customers to use the new feature