### PR TITLE
Log Kafka consumer close errors

### DIFF
--- a/packages/kafka/lib/AbstractKafkaConsumer.ts
+++ b/packages/kafka/lib/AbstractKafkaConsumer.ts
@@ -242,9 +242,11 @@ export abstract class AbstractKafkaConsumer<
       await this.consumer.close()
     } catch (err) {
       // Reporting error but not throwing further
-      this.logger.warn(resolveGlobalErrorLogObject(err), 'Error while closing Kafka consumer')
+      const resolvedErrorLog = resolveGlobalErrorLogObject(err)
+      this.logger.warn(resolvedErrorLog, 'Error while closing Kafka consumer')
       this.errorReporter.report({
         error: isError(err) ? err : new Error('Unknown error while closing Kafka consumer'),
+        context: resolvedErrorLog,
       })
     }
     this.consumer = undefined

--- a/packages/kafka/lib/AbstractKafkaConsumer.ts
+++ b/packages/kafka/lib/AbstractKafkaConsumer.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { pipeline } from 'node:stream/promises'
 import { setTimeout } from 'node:timers/promises'
 import {
-  InternalError,
+  InternalError, isError,
   resolveGlobalErrorLogObject,
   stringValueSerializer,
   type TransactionObservabilityManager,
@@ -239,8 +239,12 @@ export abstract class AbstractKafkaConsumer<
 
     try {
       await this.consumer.close()
-    } catch {
-      // Ignoring errors at this stage
+    } catch (err) {
+      // Reporting error but not throwing further
+      this.logger.warn(resolveGlobalErrorLogObject(err), 'Error while closing Kafka consumer')
+      this.errorReporter.report({
+        error: isError(err) ? err : new Error('Unknown error while closing Kafka consumer')
+      })
     }
     this.consumer = undefined
   }

--- a/packages/kafka/lib/AbstractKafkaConsumer.ts
+++ b/packages/kafka/lib/AbstractKafkaConsumer.ts
@@ -2,7 +2,8 @@ import { randomUUID } from 'node:crypto'
 import { pipeline } from 'node:stream/promises'
 import { setTimeout } from 'node:timers/promises'
 import {
-  InternalError, isError,
+  InternalError,
+  isError,
   resolveGlobalErrorLogObject,
   stringValueSerializer,
   type TransactionObservabilityManager,
@@ -243,7 +244,7 @@ export abstract class AbstractKafkaConsumer<
       // Reporting error but not throwing further
       this.logger.warn(resolveGlobalErrorLogObject(err), 'Error while closing Kafka consumer')
       this.errorReporter.report({
-        error: isError(err) ? err : new Error('Unknown error while closing Kafka consumer')
+        error: isError(err) ? err : new Error('Unknown error while closing Kafka consumer'),
       })
     }
     this.consumer = undefined


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during Kafka consumer shutdown to capture, log, and report errors that previously went unnoticed. Errors are now properly recorded with diagnostic information and reported through the system's error reporting mechanism, significantly improving observability and troubleshooting capabilities when consumer connections fail to close or encounter issues during termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->