### PR TITLE
fix(kafka): strip kafka config from Consumer.consume() args

### DIFF
--- a/packages/kafka/lib/AbstractKafkaConsumer.ts
+++ b/packages/kafka/lib/AbstractKafkaConsumer.ts
@@ -172,7 +172,12 @@ export abstract class AbstractKafkaConsumer<
     })
 
     try {
-      const { handlers: _, ...consumeOptions } = this.options // Handlers cannot be passed to consume method
+      // `kafka` is excluded so that connection-level options (including function-valued ones such
+      // as SASL/OAUTHBEARER token providers used for AWS MSK IAM) are not forwarded into
+      // `consume()`. `MessagesStream` runs `structuredClone` on the consume options and would
+      // throw `DataCloneError` if any function reached it. See:
+      // https://github.com/platformatic/kafka/blob/main/src/clients/consumer/messages-stream.ts
+      const { handlers: _, kafka: __, ...consumeOptions } = this.options // Handlers cannot be passed to consume method
 
       // https://github.com/platformatic/kafka/blob/main/docs/consumer.md#my-consumer-is-not-receiving-any-message-when-the-application-restarts
       await this.consumer.joinGroup({

--- a/packages/kafka/test/consumer/PermissionConsumer.spec.ts
+++ b/packages/kafka/test/consumer/PermissionConsumer.spec.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { waitAndRetry } from '@lokalise/universal-ts-utils/node'
-import { Producer, stringSerializers } from '@platformatic/kafka'
+import { Consumer, Producer, stringSerializers } from '@platformatic/kafka'
 import { afterAll, expect, type MockInstance } from 'vitest'
 import z from 'zod/v4'
 import { KafkaHandlerConfig, type RequestContext } from '../../lib/index.ts'
@@ -111,6 +111,51 @@ describe('PermissionConsumer', () => {
 
       // When - Then
       await expect(consumer.init()).resolves.not.toThrow()
+    })
+
+    // Regression: @platformatic/kafka's MessagesStream runs `structuredClone`
+    // on the consume options after destructuring its known fields. If the
+    // connection-level `kafka` config is forwarded, anything function-valued
+    // reachable from it (e.g. a SASL/OAUTHBEARER token provider used for AWS
+    // MSK IAM) crashes the clone with `DOMException [DataCloneError]` and
+    // prevents the consumer from starting. The toolkit must therefore strip
+    // `kafka` from consume options.
+    describe('does not forward kafka connection config to Consumer.consume()', () => {
+      it('strips `kafka` from consume options', async () => {
+        // Given
+        const consumeSpy = vi.spyOn(Consumer.prototype, 'consume')
+        consumer = new PermissionConsumer(testContext.cradle)
+
+        // When
+        await consumer.init()
+
+        // Then
+        expect(consumeSpy).toHaveBeenCalledOnce()
+        const consumeArgs = consumeSpy.mock.calls[0]![0] as unknown as Record<string, unknown>
+        expect(consumeArgs).not.toHaveProperty('kafka')
+      })
+
+      it('keeps `kafka` out of consume options even when it carries a function-valued field (e.g. SASL/OAUTHBEARER token provider)', async () => {
+        // Given - simulate AWS MSK IAM, where kafka.sasl is `{ mechanism: 'OAUTHBEARER', token: async () => '...' }`.
+        // We can't actually run SASL against the plaintext test broker, so we
+        // attach a function under `kafka` after construction. What matters is
+        // that no part of the kafka config — function-valued or otherwise —
+        // ends up in the args passed to `Consumer.consume()`.
+        const consumeSpy = vi.spyOn(Consumer.prototype, 'consume')
+        consumer = new PermissionConsumer(testContext.cradle)
+        ;(
+          consumer as unknown as { options: { kafka: Record<string, unknown> } }
+        ).options.kafka.tokenProvider = async () => 'signed-token'
+
+        // When
+        await consumer.init()
+
+        // Then
+        expect(consumeSpy).toHaveBeenCalledOnce()
+        const consumeArgs = consumeSpy.mock.calls[0]![0] as unknown as Record<string, unknown>
+        expect(consumeArgs).not.toHaveProperty('kafka')
+        expect(consumeArgs).not.toHaveProperty('tokenProvider')
+      })
     })
   })
 


### PR DESCRIPTION
## Problem
AbstractKafkaConsumer.init() forwards the entire stored options — including the connection-level kafka config — into @platformatic/kafka's Consumer.consume(). Inside consume(), the MessagesStream constructor runs structuredClone(otherOptions) on whatever it doesn't explicitly destructure. Anything function-valued reachable from the kafka config crashes that clone with DOMException [DataCloneError], taking down consumer init.

The most common trigger is AWS MSK IAM authentication, which uses SASL/OAUTHBEARER with an async token provider:

```
sasl: {
  mechanism: 'OAUTHBEARER',
  token: async () => (await generateAuthToken({ region })).token,
}
```

Production stack trace:

```
DOMException [DataCloneError]: async () => { ... } could not be cloned.
    at structuredClone (node:internal/worker/js_transferable:126:26)
    at new MessagesStream (.../@platformatic/kafka/dist/clients/consumer/messages-stream.js:142:25)
    at #performConsume (.../@platformatic/kafka/dist/clients/consumer/consumer.js:942:24)
    ...
    at AbstractKafkaConsumer.init (.../@message-queue-toolkit/kafka/dist/AbstractKafkaConsumer.js:112:19)
```

The same class of bug would hit any function-valued field passed through SASL/OAUTHBEARER providers (Confluent Cloud OIDC, etc.).

## Fix
Exclude kafka from the spread that builds consumeOptions in init():

```
- const { handlers: _, ...consumeOptions } = this.options
+ const { handlers: _, kafka: __, ...consumeOptions } = this.options
```

kafka is connection-level config — it belongs on the Consumer constructor (where it's already spread separately), not on consume(). Stripping it makes the consume args structuredClone-safe regardless of what's inside the user's connection config.

## Tests

Two regression tests in PermissionConsumer.spec.ts that spy on Consumer.prototype.consume:

- strips 'kafka' from consume options — asserts the kafka field is absent from the args.
- keeps 'kafka' out of consume options even when it carries a function-valued field — injects a function into the kafka config (simulating AWS MSK IAM sasl.token) and asserts it never reaches consume().
Verified both fail on the unfixed code — the second test reproduces the exact production stack trace — and pass with the fix applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kafka consumer configuration handling to prevent serialization errors with authentication token providers.

* **Tests**
  * Added regression test for Kafka consumer configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->