### PR TITLE
ci: fix release workflow failing on multi-package bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -300,7 +300,7 @@ jobs:
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -323,7 +323,10 @@ jobs:
             echo "Bumping version for $PKG_NAME..."
             cd "packages/$PKG_NAME"
             OLD_VERSION=$(node -p "require('./package.json').version")
-            pnpm version "$BUMP" --no-git-tag-version
+            # Use npm version (not pnpm version) — pnpm 11 enforces a clean
+            # working tree even with --no-git-tag-version, which breaks after
+            # the first package bump dirties the tree.
+            npm version "$BUMP" --no-git-tag-version
             NEW_VERSION=$(node -p "require('./package.json').version")
             echo "  $OLD_VERSION -> $NEW_VERSION"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -323,10 +323,10 @@ jobs:
             echo "Bumping version for $PKG_NAME..."
             cd "packages/$PKG_NAME"
             OLD_VERSION=$(node -p "require('./package.json').version")
-            # Use npm version (not pnpm version) — pnpm 11 enforces a clean
-            # working tree even with --no-git-tag-version, which breaks after
-            # the first package bump dirties the tree.
-            npm version "$BUMP" --no-git-tag-version
+            # --no-git-checks: skip pnpm's clean-tree check, which would
+            # otherwise fail on the second iteration once the first bump
+            # dirties the tree.
+            pnpm version "$BUMP" --no-git-tag-version --no-git-checks
             NEW_VERSION=$(node -p "require('./package.json').version")
             echo "  $OLD_VERSION -> $NEW_VERSION"
 


### PR DESCRIPTION
## Summary

The latest release run ([26020816084](https://github.com/kibertoad/message-queue-toolkit/actions/runs/26020816084)) failed at the *Bump versions for changed packages* step with:

```
[ERR_PNPM_UNCLEAN_WORKING_TREE] Working tree is not clean. Commit or stash your changes.
```

`pnpm version` runs a clean-tree check independent of `--no-git-tag-version`, so once the first package bump dirties the tree, every subsequent bump in the loop fails. pnpm exposes `--no-git-checks` as the documented escape hatch for this.

- Add `--no-git-checks` to the per-package `pnpm version` call to bypass the clean-tree check.
- Disable `actions/setup-node`'s automatic package-manager caching on the release job (`package-manager-cache: false`). The release job is a one-shot publish — caching adds noise without benefit, and v6 of setup-node enables it by default whenever \`packageManager\` is set in \`package.json\`.

## Test plan

- [ ] Merge and confirm the next qualifying PR triggers a successful publish run that bumps multiple packages in a single matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)