### PR TITLE
feat(sqs)!: explicit 20s long-polling default with opt-out

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,12 @@
 
 - **`HandlerSpy.addProcessedMessage` signature changed**: The `addProcessedMessage` method now requires a `messageType` parameter. This is an internal API change - if you're using `HandlerSpy` directly (outside of the built-in queue services), you'll need to update your calls. The library's queue services handle this automatically.
 
+- **SQS / SNS-SQS consumers now explicitly default to long polling (`waitTimeSeconds = 20`)**: Previously the toolkit relied on `sqs-consumer`'s implicit library default. The wait time is now a first-class option, `consumerPollingWaitTimeSeconds`, on `SQSConsumerOptions` (also inherited by `SNSSQSConsumerOptions`). Behavior is unchanged for existing users on the default — but you can now explicitly set `consumerPollingWaitTimeSeconds: 0` to opt into short polling (useful for tests asserting on "message was NOT processed" scenarios, or for niche prod workloads where per-poll latency matters more than long-poll efficiency). `waitTimeSeconds` has been removed from the `consumerOverrides` passthrough type — if you previously set `consumerOverrides: { waitTimeSeconds: N }`, move it to the top-level `consumerPollingWaitTimeSeconds: N`.
+
+- **`@aws-sdk/client-sqs` peer floor bumped to `^3.1034.0`** in `@message-queue-toolkit/sqs` and `@message-queue-toolkit/sns`. Driven by `sqs-consumer@15`, which is the version both packages already depend on. If you were installing the toolkit alongside `@aws-sdk/client-sqs` below `3.1034.0`, upgrade your SDK to silence the peer warning.
+
+- **Minimum Node.js raised to `>=22.0.0`** in `@message-queue-toolkit/sqs` and `@message-queue-toolkit/sns`. Driven by `sqs-consumer@15`'s LTS-only support policy. The toolkit's CI matrix has been on Node 22+ for some time, so this only formalizes what was already required.
+
 ### Migration Steps
 
 #### Replacing `messageTypeField` with `messageTypeResolver`

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -740,6 +740,7 @@ SNS consumers use the same options as SQS consumers, plus SNS-specific subscript
   concurrentConsumersAmount: 1,
   maxRetryDuration: 345600,  // 4 days
   deadLetterQueue: { /* ... */ },
+  consumerPollingWaitTimeSeconds: 20,  // long polling default; set to 0 to short-poll (e.g. in tests)
   consumerOverrides: { /* ... */ },
   // ... see SQS README for full list
 }

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -740,7 +740,11 @@ SNS consumers use the same options as SQS consumers, plus SNS-specific subscript
   concurrentConsumersAmount: 1,
   maxRetryDuration: 345600,  // 4 days
   deadLetterQueue: { /* ... */ },
-  consumerPollingWaitTimeSeconds: 20,  // long polling default; set to 0 to short-poll (e.g. in tests)
+  // SQS ReceiveMessage WaitTimeSeconds, 0–20. Defaults to 20 (full long polling)
+  // — cuts empty-receive cost, AWS API churn, and tail latency vs. short polling.
+  // Set to 0 to opt into short polling (common in tests asserting on "message
+  // was NOT processed", or for niche workloads where per-poll latency dominates).
+  consumerPollingWaitTimeSeconds: 20,
   consumerOverrides: { /* ... */ },
   // ... see SQS README for full list
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -4,6 +4,9 @@
     "private": false,
     "license": "MIT",
     "description": "SNS adapter for message-queue-toolkit",
+    "engines": {
+        "node": ">=22.0.0"
+    },
     "maintainers": [
         {
             "name": "Igor Savin",
@@ -33,7 +36,7 @@
     },
     "peerDependencies": {
         "@aws-sdk/client-sns": "^3.632.0",
-        "@aws-sdk/client-sqs": "^3.632.0",
+        "@aws-sdk/client-sqs": "^3.1034.0",
         "@aws-sdk/client-sts": "^3.632.0",
         "@message-queue-toolkit/core": ">=24.0.0",
         "@message-queue-toolkit/schemas": ">=7.0.0",
@@ -43,14 +46,14 @@
     "devDependencies": {
         "@aws-sdk/client-s3": "^3.812.0",
         "@aws-sdk/client-sns": "^3.812.0",
-        "@aws-sdk/client-sqs": "^3.812.0",
+        "@aws-sdk/client-sqs": "^3.1034.0",
         "@biomejs/biome": "^2.3.6",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/tsconfig": "^3.0.0",
         "@message-queue-toolkit/core": "*",
         "@message-queue-toolkit/redis-message-deduplication-store": "*",
         "@message-queue-toolkit/s3-payload-store": "*",
-        "@message-queue-toolkit/sqs": "*",
+        "@message-queue-toolkit/sqs": "workspace:*",
         "@types/node": "^25.0.2",
         "@vitest/coverage-v8": "^4.0.15",
         "awilix": "^13.0.3",

--- a/packages/sns/test/consumers/CreateLocateConfigMixConsumer.ts
+++ b/packages/sns/test/consumers/CreateLocateConfigMixConsumer.ts
@@ -28,6 +28,7 @@ export class CreateLocateConfigMixConsumer extends AbstractSnsSqsConsumer<
       dependencies,
       {
         handlerSpy: true,
+        consumerPollingWaitTimeSeconds: 0,
         handlers: new MessageHandlerConfigBuilder<
           SupportedMessages,
           ExecutionContext,

--- a/packages/sns/test/consumers/SnsSqsEntityConsumer.ts
+++ b/packages/sns/test/consumers/SnsSqsEntityConsumer.ts
@@ -29,6 +29,7 @@ type SnsSqsPermissionConsumerOptions = Pick<
   | 'deletionConfig'
   | 'deadLetterQueue'
   | 'consumerOverrides'
+  | 'consumerPollingWaitTimeSeconds'
   | 'maxRetryDuration'
 >
 
@@ -71,6 +72,7 @@ export class SnsSqsEntityConsumer extends AbstractSnsSqsConsumer<
         consumerOverrides: options.consumerOverrides ?? {
           terminateVisibilityTimeout: true, // this allows to retry failed messages immediately
         },
+        consumerPollingWaitTimeSeconds: options.consumerPollingWaitTimeSeconds ?? 0,
         ...(options.locatorConfig
           ? { locatorConfig: options.locatorConfig }
           : {

--- a/packages/sns/test/consumers/SnsSqsPermissionConsumer.ts
+++ b/packages/sns/test/consumers/SnsSqsPermissionConsumer.ts
@@ -37,6 +37,7 @@ type SnsSqsPermissionConsumerOptions = Pick<
   | 'deletionConfig'
   | 'deadLetterQueue'
   | 'consumerOverrides'
+  | 'consumerPollingWaitTimeSeconds'
   | 'maxRetryDuration'
   | 'payloadStoreConfig'
   | 'concurrentConsumersAmount'
@@ -150,6 +151,7 @@ export class SnsSqsPermissionConsumer extends AbstractSnsSqsConsumer<
         consumerOverrides: options.consumerOverrides ?? {
           terminateVisibilityTimeout: true, // this allows to retry failed messages immediately
         },
+        consumerPollingWaitTimeSeconds: options.consumerPollingWaitTimeSeconds ?? 0,
         deadLetterQueue: options.deadLetterQueue,
         ...(options.locatorConfig
           ? { locatorConfig: options.locatorConfig, creationConfig: options.creationConfig as any }

--- a/packages/sns/test/consumers/SnsSqsPermissionConsumerFifo.ts
+++ b/packages/sns/test/consumers/SnsSqsPermissionConsumerFifo.ts
@@ -143,6 +143,7 @@ export class SnsSqsPermissionConsumerFifo extends AbstractSnsSqsConsumer<
         consumerOverrides: options.consumerOverrides ?? {
           terminateVisibilityTimeout: true, // this allows to retry failed messages immediately
         },
+        consumerPollingWaitTimeSeconds: options.consumerPollingWaitTimeSeconds ?? 0,
         deadLetterQueue: options.deadLetterQueue,
         ...(options.locatorConfig
           ? { locatorConfig: options.locatorConfig, creationConfig: options.creationConfig as any }

--- a/packages/sqs/README.md
+++ b/packages/sqs/README.md
@@ -512,6 +512,13 @@ When using `locatorConfig`, you connect to an existing queue without creating it
     },
   },
 
+  // Optional - Long Polling (SQS ReceiveMessage WaitTimeSeconds, 0–20)
+  // Defaults to 20 (full long polling). Cuts empty-receive cost, AWS API
+  // churn, and tail latency vs. short polling. Set to 0 to opt into short
+  // polling — common for tests that assert on "message was NOT processed"
+  // scenarios, or for niche prod workloads where per-poll latency dominates.
+  consumerPollingWaitTimeSeconds: 20,
+
   // Optional - Consumer Behavior
   consumerOverrides: {
     batchSize: 10,                     // Messages per receive (1-10)

--- a/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
@@ -47,6 +47,19 @@ const DEFAULT_BARRIER_SLEEP_CHECK_INTERVAL_IN_MSECS = 5000 // 5 seconds in milli
 const DEFAULT_BARRIER_VISIBILITY_EXTENSION_INTERVAL_IN_MSECS = 30000 // 30 seconds in milliseconds
 const DEFAULT_BARRIER_VISIBILITY_TIMEOUT_IN_SECONDS = 90 // 90 seconds
 const DEFAULT_CONSUMER_POLLING_WAIT_TIME_SECONDS = 20 // 20 seconds (full SQS long-polling)
+const MAX_CONSUMER_POLLING_WAIT_TIME_SECONDS = 20 // AWS SQS ReceiveMessage upper bound
+
+function resolveConsumerPollingWaitTimeSeconds(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_CONSUMER_POLLING_WAIT_TIME_SECONDS
+
+  if (!Number.isInteger(value) || value < 0 || value > MAX_CONSUMER_POLLING_WAIT_TIME_SECONDS) {
+    throw new RangeError(
+      `consumerPollingWaitTimeSeconds must be an integer between 0 and ${MAX_CONSUMER_POLLING_WAIT_TIME_SECONDS} (inclusive). Received: ${value}`,
+    )
+  }
+
+  return value
+}
 
 type SQSDeadLetterQueueOptions = {
   redrivePolicy: {
@@ -74,9 +87,10 @@ type SQSConsumerCommonOptions<
 > & {
   /**
    * Wait time in seconds the consumer passes to SQS ReceiveMessage (long-polling).
-   * AWS allows 0–20. Defaults to 20 (full long polling), which is almost always
-   * what you want in production — it cuts empty-receive cost, AWS API churn,
-   * and tail latency compared to short polling.
+   * AWS allows integer values 0–20; anything else throws a RangeError at
+   * construction time. Defaults to 20 (full long polling), which is almost
+   * always what you want in production — it cuts empty-receive cost, AWS API
+   * churn, and tail latency compared to short polling.
    *
    * Set to 0 to opt into short polling. Common reasons:
    *   - Test suites asserting on "message was NOT processed" scenarios that
@@ -246,8 +260,9 @@ export abstract class AbstractSqsConsumer<
       DEFAULT_BARRIER_VISIBILITY_EXTENSION_INTERVAL_IN_MSECS
     this.barrierVisibilityTimeoutInSeconds =
       fifoOptions.barrierVisibilityTimeoutInSeconds ?? DEFAULT_BARRIER_VISIBILITY_TIMEOUT_IN_SECONDS
-    this.consumerPollingWaitTimeSeconds =
-      options.consumerPollingWaitTimeSeconds ?? DEFAULT_CONSUMER_POLLING_WAIT_TIME_SECONDS
+    this.consumerPollingWaitTimeSeconds = resolveConsumerPollingWaitTimeSeconds(
+      options.consumerPollingWaitTimeSeconds,
+    )
     this.executionContext = executionContext
     this.consumers = []
     this.concurrentConsumersAmount = options.concurrentConsumersAmount ?? 1
@@ -332,13 +347,14 @@ export abstract class AbstractSqsConsumer<
       sqs: this.sqsClient,
       queueUrl: this.queueUrl,
       visibilityTimeout: options.visibilityTimeout,
-      waitTimeSeconds: this.consumerPollingWaitTimeSeconds,
       messageAttributeNames: [`${PAYLOAD_OFFLOADING_ATTRIBUTE_PREFIX}*`],
       // For FIFO queues, request system attributes needed for retry (MessageGroupId and MessageDeduplicationId)
       messageSystemAttributeNames: this.isFifoQueue
         ? ['MessageGroupId', 'MessageDeduplicationId']
         : undefined,
       ...this.consumerOptionsOverride,
+      // Keep polling wait controlled only by the top-level consumerPollingWaitTimeSeconds.
+      waitTimeSeconds: this.consumerPollingWaitTimeSeconds,
       // Suppress FIFO warning (set after overrides to ensure it's not overridden)
       suppressFifoWarning: this.isFifoQueue ? true : undefined,
       // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: fixme

--- a/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsConsumer.ts
@@ -46,6 +46,7 @@ const DEFAULT_MAX_RETRY_DURATION = 4 * 24 * 60 * 60 // 4 days in seconds
 const DEFAULT_BARRIER_SLEEP_CHECK_INTERVAL_IN_MSECS = 5000 // 5 seconds in milliseconds
 const DEFAULT_BARRIER_VISIBILITY_EXTENSION_INTERVAL_IN_MSECS = 30000 // 30 seconds in milliseconds
 const DEFAULT_BARRIER_VISIBILITY_TIMEOUT_IN_SECONDS = 90 // 90 seconds
+const DEFAULT_CONSUMER_POLLING_WAIT_TIME_SECONDS = 20 // 20 seconds (full SQS long-polling)
 
 type SQSDeadLetterQueueOptions = {
   redrivePolicy: {
@@ -72,8 +73,23 @@ type SQSConsumerCommonOptions<
   SQSQueueLocatorType
 > & {
   /**
-   * Omitting properties which will be set internally ins this class
-   * `visibilityTimeout` is also omitted to avoid conflicts with queue config
+   * Wait time in seconds the consumer passes to SQS ReceiveMessage (long-polling).
+   * AWS allows 0–20. Defaults to 20 (full long polling), which is almost always
+   * what you want in production — it cuts empty-receive cost, AWS API churn,
+   * and tail latency compared to short polling.
+   *
+   * Set to 0 to opt into short polling. Common reasons:
+   *   - Test suites asserting on "message was NOT processed" scenarios that
+   *     should not block 20s per poll cycle.
+   *   - Prod workloads where per-poll latency genuinely matters more than
+   *     long-poll efficiency (rare).
+   */
+  consumerPollingWaitTimeSeconds?: number
+
+  /**
+   * Omitting properties which will be set internally in this class.
+   * `visibilityTimeout` is omitted to avoid conflicts with queue config.
+   * `waitTimeSeconds` is omitted in favor of `consumerPollingWaitTimeSeconds`.
    */
   consumerOverrides?: Omit<
     ConsumerOptions,
@@ -82,6 +98,7 @@ type SQSConsumerCommonOptions<
     | 'handler'
     | 'handleMessageBatch'
     | 'visibilityTimeout'
+    | 'waitTimeSeconds'
     | 'messageAttributeNames'
     | 'messageSystemAttributeNames'
     | 'attributeNames'
@@ -193,6 +210,7 @@ export abstract class AbstractSqsConsumer<
   private readonly barrierSleepCheckIntervalInMsecs: number
   private readonly barrierVisibilityExtensionIntervalInMsecs: number
   private readonly barrierVisibilityTimeoutInSeconds: number
+  private readonly consumerPollingWaitTimeSeconds: number
 
   protected deadLetterQueueUrl?: string
   protected readonly errorResolver: ErrorResolver
@@ -228,6 +246,8 @@ export abstract class AbstractSqsConsumer<
       DEFAULT_BARRIER_VISIBILITY_EXTENSION_INTERVAL_IN_MSECS
     this.barrierVisibilityTimeoutInSeconds =
       fifoOptions.barrierVisibilityTimeoutInSeconds ?? DEFAULT_BARRIER_VISIBILITY_TIMEOUT_IN_SECONDS
+    this.consumerPollingWaitTimeSeconds =
+      options.consumerPollingWaitTimeSeconds ?? DEFAULT_CONSUMER_POLLING_WAIT_TIME_SECONDS
     this.executionContext = executionContext
     this.consumers = []
     this.concurrentConsumersAmount = options.concurrentConsumersAmount ?? 1
@@ -312,6 +332,7 @@ export abstract class AbstractSqsConsumer<
       sqs: this.sqsClient,
       queueUrl: this.queueUrl,
       visibilityTimeout: options.visibilityTimeout,
+      waitTimeSeconds: this.consumerPollingWaitTimeSeconds,
       messageAttributeNames: [`${PAYLOAD_OFFLOADING_ATTRIBUTE_PREFIX}*`],
       // For FIFO queues, request system attributes needed for retry (MessageGroupId and MessageDeduplicationId)
       messageSystemAttributeNames: this.isFifoQueue

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -4,6 +4,9 @@
     "private": false,
     "license": "MIT",
     "description": "SQS adapter for message-queue-toolkit",
+    "engines": {
+        "node": ">=22.0.0"
+    },
     "maintainers": [
         {
             "name": "Igor Savin",
@@ -32,13 +35,13 @@
         "sqs-consumer": "^15.0.1"
     },
     "peerDependencies": {
-        "@aws-sdk/client-sqs": "^3.632.0",
+        "@aws-sdk/client-sqs": "^3.1034.0",
         "@message-queue-toolkit/core": ">=25.0.0",
         "zod": ">=3.25.76 <5.0.0"
     },
     "devDependencies": {
         "@aws-sdk/client-s3": "^3.812.0",
-        "@aws-sdk/client-sqs": "^3.812.0",
+        "@aws-sdk/client-sqs": "^3.1034.0",
         "@biomejs/biome": "^2.3.8",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/tsconfig": "^3.0.0",

--- a/packages/sqs/test/consumers/SqsConsumer.pollingWaitTime.spec.ts
+++ b/packages/sqs/test/consumers/SqsConsumer.pollingWaitTime.spec.ts
@@ -1,7 +1,7 @@
 import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
 import type { AwilixContainer } from 'awilix'
 import { Consumer } from 'sqs-consumer'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest'
 
 import type { SQSConsumerDependencies } from '../../lib/sqs/AbstractSqsConsumer.ts'
 import { AbstractSqsConsumer } from '../../lib/sqs/AbstractSqsConsumer.ts'
@@ -46,7 +46,7 @@ describe('AbstractSqsConsumer polling wait time wiring', () => {
   const queueName = 'pollingWaitTimeQueue'
 
   let diContainer: AwilixContainer<Dependencies>
-  let createSpy: ReturnType<typeof vi.spyOn>
+  let createSpy: MockInstance<typeof Consumer.create>
 
   beforeEach(async () => {
     diContainer = await registerDependencies()
@@ -84,6 +84,7 @@ describe('AbstractSqsConsumer polling wait time wiring', () => {
 
     await consumer.start()
 
+    expect(createSpy).toHaveBeenCalledTimes(1)
     expect(createSpy.mock.calls[0]?.[0]).toMatchObject({ waitTimeSeconds: 0 })
 
     await consumer.close()
@@ -94,8 +95,30 @@ describe('AbstractSqsConsumer polling wait time wiring', () => {
 
     await consumer.start()
 
+    expect(createSpy).toHaveBeenCalledTimes(1)
     expect(createSpy.mock.calls[0]?.[0]).toMatchObject({ waitTimeSeconds: 5 })
 
     await consumer.close()
+  })
+
+  it('accepts the AWS upper bound of 20 (long polling max)', async () => {
+    const consumer = new MinimalSqsConsumer(diContainer.cradle, queueName, 20)
+
+    await consumer.start()
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(createSpy.mock.calls[0]?.[0]).toMatchObject({ waitTimeSeconds: 20 })
+
+    await consumer.close()
+  })
+
+  it.each([
+    ['above the upper bound', 21],
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['NaN', Number.NaN],
+  ])('throws on invalid consumerPollingWaitTimeSeconds (%s)', (_label, value) => {
+    expect(() => new MinimalSqsConsumer(diContainer.cradle, queueName, value)).toThrow(RangeError)
+    expect(createSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/sqs/test/consumers/SqsConsumer.pollingWaitTime.spec.ts
+++ b/packages/sqs/test/consumers/SqsConsumer.pollingWaitTime.spec.ts
@@ -1,0 +1,101 @@
+import { MessageHandlerConfigBuilder } from '@message-queue-toolkit/core'
+import type { AwilixContainer } from 'awilix'
+import { Consumer } from 'sqs-consumer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SQSConsumerDependencies } from '../../lib/sqs/AbstractSqsConsumer.ts'
+import { AbstractSqsConsumer } from '../../lib/sqs/AbstractSqsConsumer.ts'
+import type { Dependencies } from '../utils/testContext.ts'
+import { registerDependencies } from '../utils/testContext.ts'
+import {
+  PERMISSIONS_ADD_MESSAGE_SCHEMA,
+  type PERMISSIONS_ADD_MESSAGE_TYPE,
+} from './userConsumerSchemas.ts'
+
+type ExecutionContext = { incrementAmount: number }
+
+class MinimalSqsConsumer extends AbstractSqsConsumer<
+  PERMISSIONS_ADD_MESSAGE_TYPE,
+  ExecutionContext
+> {
+  constructor(
+    dependencies: SQSConsumerDependencies,
+    queueName: string,
+    consumerPollingWaitTimeSeconds: number | undefined,
+  ) {
+    super(
+      dependencies,
+      {
+        creationConfig: { queue: { QueueName: queueName } },
+        deletionConfig: { deleteIfExists: true },
+        messageTypeResolver: { messageTypePath: 'messageType' },
+        handlerSpy: true,
+        ...(consumerPollingWaitTimeSeconds !== undefined ? { consumerPollingWaitTimeSeconds } : {}),
+        handlers: new MessageHandlerConfigBuilder<PERMISSIONS_ADD_MESSAGE_TYPE, ExecutionContext>()
+          .addConfig(PERMISSIONS_ADD_MESSAGE_SCHEMA, () =>
+            Promise.resolve({ result: 'success' as const }),
+          )
+          .build(),
+      },
+      { incrementAmount: 1 },
+    )
+  }
+}
+
+describe('AbstractSqsConsumer polling wait time wiring', () => {
+  const queueName = 'pollingWaitTimeQueue'
+
+  let diContainer: AwilixContainer<Dependencies>
+  let createSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    diContainer = await registerDependencies()
+    await diContainer.cradle.testAdmin.deleteQueues(queueName)
+
+    createSpy = vi.spyOn(Consumer, 'create').mockImplementation(
+      () =>
+        ({
+          on: () => undefined,
+          start: () => undefined,
+          stop: () => undefined,
+        }) as unknown as ReturnType<typeof Consumer.create>,
+    )
+  })
+
+  afterEach(async () => {
+    createSpy.mockRestore()
+    await diContainer.cradle.awilixManager.executeDispose()
+    await diContainer.dispose()
+  })
+
+  it('defaults waitTimeSeconds to 20 (long polling)', async () => {
+    const consumer = new MinimalSqsConsumer(diContainer.cradle, queueName, undefined)
+
+    await consumer.start()
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(createSpy.mock.calls[0]?.[0]).toMatchObject({ waitTimeSeconds: 20 })
+
+    await consumer.close()
+  })
+
+  it('passes waitTimeSeconds: 0 when consumerPollingWaitTimeSeconds is 0 (short polling opt-out)', async () => {
+    const consumer = new MinimalSqsConsumer(diContainer.cradle, queueName, 0)
+
+    await consumer.start()
+
+    expect(createSpy.mock.calls[0]?.[0]).toMatchObject({ waitTimeSeconds: 0 })
+
+    await consumer.close()
+  })
+
+  it('passes the user-provided waitTimeSeconds value through verbatim', async () => {
+    const consumer = new MinimalSqsConsumer(diContainer.cradle, queueName, 5)
+
+    await consumer.start()
+
+    expect(createSpy.mock.calls[0]?.[0]).toMatchObject({ waitTimeSeconds: 5 })
+
+    await consumer.close()
+  })
+})

--- a/packages/sqs/test/consumers/SqsEventBridgeConsumer.ts
+++ b/packages/sqs/test/consumers/SqsEventBridgeConsumer.ts
@@ -60,6 +60,9 @@ export class SqsEventBridgeConsumer extends AbstractSqsConsumer<
         // Enable handler spy for testing
         handlerSpy: true,
 
+        // Short-poll in tests; the toolkit default is 20s long-polling.
+        consumerPollingWaitTimeSeconds: 0,
+
         // Handler configuration
         // Handlers receive the full EventBridge envelope and can access message.detail
         handlers: new MessageHandlerConfigBuilder<

--- a/packages/sqs/test/consumers/SqsPermissionConsumer.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumer.ts
@@ -27,6 +27,7 @@ type SqsPermissionConsumerOptions = Pick<
   | 'deletionConfig'
   | 'deadLetterQueue'
   | 'consumerOverrides'
+  | 'consumerPollingWaitTimeSeconds'
   | 'maxRetryDuration'
   | 'payloadStoreConfig'
   | 'messageDeduplicationConfig'
@@ -121,6 +122,7 @@ export class SqsPermissionConsumer extends AbstractSqsConsumer<
         consumerOverrides: options.consumerOverrides ?? {
           terminateVisibilityTimeout: true, // this allows to retry failed messages immediately
         },
+        consumerPollingWaitTimeSeconds: options.consumerPollingWaitTimeSeconds ?? 0,
         concurrentConsumersAmount: options.concurrentConsumersAmount,
         maxRetryDuration: options.maxRetryDuration,
         payloadStoreConfig: options.payloadStoreConfig,

--- a/packages/sqs/test/consumers/SqsPermissionConsumerFifo.ts
+++ b/packages/sqs/test/consumers/SqsPermissionConsumerFifo.ts
@@ -125,6 +125,7 @@ export class SqsPermissionConsumerFifo extends AbstractSqsConsumer<
         consumerOverrides: options.consumerOverrides ?? {
           terminateVisibilityTimeout: true, // this allows to retry failed messages immediately
         },
+        consumerPollingWaitTimeSeconds: options.consumerPollingWaitTimeSeconds ?? 0,
         concurrentConsumersAmount: options.concurrentConsumersAmount,
         maxRetryDuration: options.maxRetryDuration,
         barrierSleepCheckIntervalInMsecs: options.barrierSleepCheckIntervalInMsecs,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,7 +486,7 @@ importers:
         specifier: ^3.812.0
         version: 3.1048.0
       '@aws-sdk/client-sqs':
-        specifier: ^3.812.0
+        specifier: ^3.1034.0
         version: 3.1048.0
       '@biomejs/biome':
         specifier: ^2.3.6
@@ -507,8 +507,8 @@ importers:
         specifier: '*'
         version: 3.0.0(@aws-sdk/client-s3@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))
       '@message-queue-toolkit/sqs':
-        specifier: '*'
-        version: 24.2.1(@aws-sdk/client-sqs@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(zod@4.4.3)
+        specifier: workspace:*
+        version: link:../sqs
       '@types/node':
         specifier: ^25.0.2
         version: 25.8.0
@@ -553,7 +553,7 @@ importers:
         specifier: ^3.812.0
         version: 3.1048.0
       '@aws-sdk/client-sqs':
-        specifier: ^3.812.0
+        specifier: ^3.1034.0
         version: 3.1048.0
       '@biomejs/biome':
         specifier: ^2.3.8
@@ -1000,13 +1000,6 @@ packages:
   '@message-queue-toolkit/schemas@7.1.0':
     resolution: {integrity: sha512-JAzSQAHouympK/cEDBxsfEuS2Ifu1pv0a/NRvhNWfFlgW0TmsWT7SkYNERA7x89OK7PGk9PyDN88cV9l0gZ22Q==}
     peerDependencies:
-      zod: '>=3.25.76 <5.0.0'
-
-  '@message-queue-toolkit/sqs@24.2.1':
-    resolution: {integrity: sha512-R3+XSzvBUStsjbjKWtTIb64PD/4+cUM0CrqiATuPj4XUK0WTzCYhHF42okk+6k1Nv5H3U7P1gGXgeotBGRKadg==}
-    peerDependencies:
-      '@aws-sdk/client-sqs': ^3.632.0
-      '@message-queue-toolkit/core': '>=25.0.0'
       zod: '>=3.25.76 <5.0.0'
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
@@ -2460,12 +2453,6 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  sqs-consumer@14.2.8:
-    resolution: {integrity: sha512-Iq3AdASfsxY2s3KL88aPRGgvST3gviZphL5teTKxUqDZzXRIB8s6SWATft+v7YaGMspCs8BwrOKo9vD6ltcJmw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-sqs': ^3.1018.0
-
   sqs-consumer@15.0.1:
     resolution: {integrity: sha512-cDcSkekXxhLMn3u+FSnAG3Ryh6jwHMPna1/oqs2dUL0gvUXOLLMa2Yzu0K4QqwVyaH0MDZw1IU7+W+W618/xcw==}
     engines: {node: '>=22.0.0'}
@@ -3386,16 +3373,6 @@ snapshots:
   '@message-queue-toolkit/schemas@7.1.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
-
-  '@message-queue-toolkit/sqs@24.2.1(@aws-sdk/client-sqs@3.1048.0)(@message-queue-toolkit/core@25.5.0(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@aws-sdk/client-sqs': 3.1048.0
-      '@lokalise/node-core': 14.8.1(zod@4.4.3)
-      '@message-queue-toolkit/core': 25.5.0(zod@4.4.3)
-      sqs-consumer: 14.2.8(@aws-sdk/client-sqs@3.1048.0)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -4806,13 +4783,6 @@ snapshots:
   source-map-js@1.2.1: {}
 
   split2@4.2.0: {}
-
-  sqs-consumer@14.2.8(@aws-sdk/client-sqs@3.1048.0):
-    dependencies:
-      '@aws-sdk/client-sqs': 3.1048.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   sqs-consumer@15.0.1(@aws-sdk/client-sqs@3.1048.0):
     dependencies:


### PR DESCRIPTION
## Summary

- Make SQS long polling (`waitTimeSeconds=20`) the toolkit's **explicit** default instead of relying on `sqs-consumer`'s implicit library default. New top-level option `consumerPollingWaitTimeSeconds` on `SQSConsumerOptions` (inherited by `SNSSQSConsumerOptions`); set to `0` for short-poll opt-out.
- Bundle in `sqs-consumer@15` dependency hygiene: bump `@aws-sdk/client-sqs` peer floor to `^3.1034.0`, declare `engines.node: ">=22.0.0"` in both `sqs` and `sns` packages, switch SNS's devDep on `@message-queue-toolkit/sqs` to `workspace:*` so its tests type-check against in-tree SQS source.
- Test consumers in both packages now default to `consumerPollingWaitTimeSeconds: 0` so negative-path tests don't block 20s per poll cycle.

## Why

Today `AbstractSqsConsumer` calls `Consumer.create({...})` without passing `waitTimeSeconds`, so behavior depends on `sqs-consumer`'s implicit default of 20. Three problems with that:

1. **Implicit contract** — a major version of `sqs-consumer` could change its default and silently flip the toolkit to short polling.
2. **No discoverable opt-out** — the only knob was `consumerOverrides.waitTimeSeconds`, which most users won't find. Tests asserting on "message was NOT processed" scenarios paid the full 20s wait.
3. **Stale peer/engine surface** — `sqs-consumer@15` (already declared as `^15.0.1` in source) requires `@aws-sdk/client-sqs ^3.1034.0` and Node `>=22.0.0`, but the toolkit's peer ranges still pinned `^3.632.0` and had no `engines.node` declared. Anyone installing on the floor of the toolkit's range got peer warnings.

## What changes for users

- **Default behavior is unchanged** for anyone already on the implicit 20s default.
- **New top-level option**: `consumerPollingWaitTimeSeconds?: number` (default `20`). Set to `0` to short-poll.
- **`consumerOverrides.waitTimeSeconds` is no longer accepted** — it's been removed from the passthrough type's `Omit` list. Move it to the top-level option. This is a TS-level breaking change only; runtime behavior is unchanged at the default.
- **`@aws-sdk/client-sqs` peer floor** bumped to `^3.1034.0` in `@message-queue-toolkit/sqs` and `@message-queue-toolkit/sns`.
- **Minimum Node** raised to `>=22.0.0` in both packages (matches the existing CI matrix of 22.x / 24.x).

`UPGRADING.md` has been updated under the next-major section.

## Test plan

- [x] `pnpm -F @message-queue-toolkit/sqs build` — clean
- [x] `pnpm -F @message-queue-toolkit/sns build` — clean
- [x] `pnpm -F @message-queue-toolkit/sqs exec vitest run` — 183 / 183 passing
- [x] `pnpm -F @message-queue-toolkit/sns exec vitest run` — 121 / 121 passing (2 pre-existing skips), 0 type errors
- [x] `pnpm -F @message-queue-toolkit/sqs exec tsc --noEmit` — clean
- [x] `pnpm -F @message-queue-toolkit/sns exec tsc --noEmit` — clean
- [x] Targeted regression spec (`SqsConsumer.pollingWaitTime.spec.ts`) verifies `Consumer.create` receives `waitTimeSeconds: 20` by default, `0` when option is `0`, and the user-provided value verbatim otherwise.
- [x] `pnpm install` — no peer warnings related to `@aws-sdk/client-sqs` / `sqs-consumer`.
- [x] `biome check` clean on all files modified in this PR. Two pre-existing `useOptionalChain` warnings in `AbstractSqsConsumer.ts` (lines 902, 929) are in code untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Node.js minimum version raised to 22.0.0
  * `consumerOverrides.waitTimeSeconds` removed; use new `consumerPollingWaitTimeSeconds` option instead
  * AWS SDK peer dependency updated to ^3.1034.0

* **New Features**
  * Added explicit `consumerPollingWaitTimeSeconds` configuration for SQS and SNS consumers to control polling behavior (defaults: SQS=20s long polling, SNS=0s short polling)

* **Documentation**
  * Added comprehensive upgrade guide for v26.0.0 with migration instructions
  * Updated consumer configuration examples with new polling option

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kibertoad/message-queue-toolkit/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->