### PR TITLE
feat(core): expose payload-offloading flag on handlerSpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,23 @@ const result = await myConsumer.handlerSpy.waitForMessageWithId('1')
 expect(result.processingResult).toEqual({ status: 'consumed' })
 ```
 
+When [payload offloading](#payload-offloading) is configured, the publisher's processing result
+exposes whether the message was offloaded to the external payload store. This lets you assert the
+offloading path was taken without mocking the store:
+
+```ts
+// Large message — payload was offloaded
+const offloaded = await myPublisher.handlerSpy.waitForMessageWithId('1', 'published')
+expect(offloaded.processingResult).toEqual({ status: 'published', offloaded: true })
+
+// Small message — sent inline, `offloaded` is omitted
+const inline = await myPublisher.handlerSpy.waitForMessageWithId('2', 'published')
+expect(inline.processingResult.offloaded).toBeUndefined()
+```
+
+The `offloaded` field is only present (set to `true`) when offloading actually happened, so existing
+exact-match assertions such as `toEqual({ status: 'published' })` keep passing for inline messages.
+
 ### Counters
 
 For load-testing scenarios where retaining all messages in the buffer may be too memory-intensive, handler spies provide lightweight counters that track how many messages were processed with each status:

--- a/packages/core/lib/types/MessageQueueTypes.ts
+++ b/packages/core/lib/types/MessageQueueTypes.ts
@@ -17,8 +17,14 @@ export type MessageProcessingResult =
       status: 'retryLater'
     }
   | {
-      status: 'consumed' | 'published'
+      status: 'consumed'
       skippedAsDuplicate?: boolean
+    }
+  | {
+      status: 'published'
+      skippedAsDuplicate?: boolean
+      // Only set (to `true`) when the message payload was offloaded to the external
+      // payload store; omitted entirely for inline messages.
       offloaded?: boolean
     }
   | {

--- a/packages/core/lib/types/MessageQueueTypes.ts
+++ b/packages/core/lib/types/MessageQueueTypes.ts
@@ -19,6 +19,7 @@ export type MessageProcessingResult =
   | {
       status: 'consumed' | 'published'
       skippedAsDuplicate?: boolean
+      offloaded?: boolean
     }
   | {
       status: 'error'

--- a/packages/gcp-pubsub/lib/pubsub/AbstractPubSubPublisher.ts
+++ b/packages/gcp-pubsub/lib/pubsub/AbstractPubSubPublisher.ts
@@ -4,6 +4,7 @@ import {
   type AsyncPublisher,
   type BarrierResult,
   DeduplicationRequesterEnum,
+  isOffloadedPayloadPointerPayload,
   type MessageInvalidFormatError,
   type MessageSchemaContainer,
   type MessageValidationError,
@@ -99,7 +100,9 @@ export abstract class AbstractPubSubPublisher<MessagePayloadType extends object>
       await this.sendMessage(maybeOffloadedPayloadMessage, options)
       this.handleMessageProcessed({
         message: parsedMessage,
-        processingResult: { status: 'published' },
+        processingResult: isOffloadedPayloadPointerPayload(maybeOffloadedPayloadMessage)
+          ? { status: 'published', offloaded: true }
+          : { status: 'published' },
         messageProcessingStartTimestamp,
         queueName: this.topicName,
       })

--- a/packages/sns/lib/sns/AbstractSnsPublisher.ts
+++ b/packages/sns/lib/sns/AbstractSnsPublisher.ts
@@ -6,6 +6,7 @@ import {
   type AsyncPublisher,
   type BarrierResult,
   DeduplicationRequesterEnum,
+  isOffloadedPayloadPointerPayload,
   type MessageInvalidFormatError,
   type MessageSchemaContainer,
   type MessageValidationError,
@@ -169,7 +170,9 @@ export abstract class AbstractSnsPublisher<MessagePayloadType extends object>
 
       this.handleMessageProcessed({
         message: parsedMessage,
-        processingResult: { status: 'published' },
+        processingResult: isOffloadedPayloadPointerPayload(payload)
+          ? { status: 'published', offloaded: true }
+          : { status: 'published' },
         messageProcessingStartTimestamp,
         queueName: topicName,
       })

--- a/packages/sns/test/publishers/SnsPermissionPublisher.payloadOffloading.spec.ts
+++ b/packages/sns/test/publishers/SnsPermissionPublisher.payloadOffloading.spec.ts
@@ -118,9 +118,10 @@ describe('SnsPermissionPublisher - single-store payload offloading', () => {
 
       await publisher.publish(message)
 
-      await expect(
-        publisher.handlerSpy.waitForMessageWithId('1', 'published'),
-      ).resolves.toBeDefined()
+      // The handler spy exposes that the message took the offloading path, so tests can
+      // assert offloading happened without inspecting the store directly.
+      const spyResult = await publisher.handlerSpy.waitForMessageWithId('1', 'published')
+      expect(spyResult.processingResult).toEqual({ status: 'published', offloaded: true })
       await waitAndRetry(() => receivedSnsMessages.length > 0)
 
       // Check that the published message's body is a pointer to the offloaded payload.

--- a/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
+++ b/packages/sqs/lib/sqs/AbstractSqsPublisher.ts
@@ -6,6 +6,7 @@ import {
   type AsyncPublisher,
   type BarrierResult,
   DeduplicationRequesterEnum,
+  isOffloadedPayloadPointerPayload,
   type MessageInvalidFormatError,
   type MessageSchemaContainer,
   type MessageValidationError,
@@ -160,7 +161,9 @@ export abstract class AbstractSqsPublisher<MessagePayloadType extends object>
       await this.sendMessage(payload, resolvedOptions, preBuiltBody)
       this.handleMessageProcessed({
         message: parsedMessage,
-        processingResult: { status: 'published' },
+        processingResult: isOffloadedPayloadPointerPayload(payload)
+          ? { status: 'published', offloaded: true }
+          : { status: 'published' },
         messageProcessingStartTimestamp,
         queueName: this.queue.name,
       })

--- a/packages/sqs/test/publishers/SqsPermissionPublisher.payloadOffloading.spec.ts
+++ b/packages/sqs/test/publishers/SqsPermissionPublisher.payloadOffloading.spec.ts
@@ -98,9 +98,10 @@ describe('SqsPermissionPublisher - payload offloading', () => {
 
       await publisher.publish(message)
 
-      await expect(
-        publisher.handlerSpy.waitForMessageWithId('1', 'published'),
-      ).resolves.toBeDefined()
+      // The handler spy exposes that the message took the offloading path, so tests can
+      // assert offloading happened without inspecting the store directly.
+      const spyResult = await publisher.handlerSpy.waitForMessageWithId('1', 'published')
+      expect(spyResult.processingResult).toEqual({ status: 'published', offloaded: true })
       await waitAndRetry(() => receivedSqsMessages.length > 0)
 
       // Check that the published message's body is a pointer to the offloaded payload.
@@ -139,6 +140,28 @@ describe('SqsPermissionPublisher - payload offloading', () => {
       await expect(
         getObjectContent(s3, s3BucketName, offloadedPayloadPointer),
       ).resolves.toBeDefined()
+    })
+
+    it('does not flag small messages as offloaded', async () => {
+      const message = {
+        id: '2',
+        messageType: 'add',
+      } satisfies PERMISSIONS_ADD_MESSAGE_TYPE
+      expect(JSON.stringify(message).length).toBeLessThan(largeMessageSizeThreshold)
+
+      await publisher.publish(message)
+
+      const spyResult = await publisher.handlerSpy.waitForMessageWithId('2', 'published')
+      // `offloaded` is omitted entirely for inline messages, so the exact-match holds.
+      expect(spyResult.processingResult).toEqual({ status: 'published' })
+      await waitAndRetry(() => receivedSqsMessages.length > 0)
+
+      // Small messages are sent inline, not as an offloaded-payload pointer.
+      expect(receivedSqsMessages.length).toBe(1)
+      const parsedReceivedMessageBody = JSON.parse(receivedSqsMessages[0]!.Body!)
+      expect(parsedReceivedMessageBody.payloadRef).toBeUndefined()
+      expect(parsedReceivedMessageBody.offloadedPayloadPointer).toBeUndefined()
+      expect(parsedReceivedMessageBody.id).toBe('2')
     })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2710,14 +2710,6 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
@@ -5443,16 +5435,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
## Summary

Publishers that offload large payloads to an external store (e.g. S3) now report `offloaded: true` on their `published` processing result, so tests can assert the offloading path was taken **without mocking the payload store**.

Motivated by a [review comment in lokalise/maestro#1481](https://github.com/lokalise/maestro/pull/1481#discussion_r3267243771): verifying that a publish offloaded to S3 previously required hand-mocking the store, because `handlerSpy` didn't expose whether offloading happened.

## Changes

- **`packages/core/lib/types/MessageQueueTypes.ts`** — add optional `offloaded?: boolean` to the `consumed | published` variant of `MessageProcessingResult`. Additive, non-breaking.
- **SQS / SNS / PubSub publishers** — set `offloaded: true` on the success-path result, detected via the existing exported `isOffloadedPayloadPointerPayload()` guard (the returned payload *is* the offload pointer when offloading happened). Kafka/AMQP publishers don't offload and are untouched. No change needed in `HandlerSpy.ts` — it passes `processingResult` through verbatim.
- **`README.md`** — document the new field in the handler-spy section with a test snippet.
- **Tests** — `SqsPermissionPublisher.payloadOffloading.spec.ts`: the large-message test asserts `{ status: 'published', offloaded: true }`; a new small-message test asserts the field is omitted on the inline path.

The flag is **omitted when offloading did not occur**, so existing exact-match assertions such as `toEqual({ status: 'published' })` keep passing.

## Usage

```ts
const result = await publisher.handlerSpy.waitForMessageWithId('1', 'published')
expect(result.processingResult).toEqual({ status: 'published', offloaded: true })
```

## Verification

- Build: all 12 packages build clean via turbo.
- Typecheck: `tsc` (incl. tests) passes for core, sqs, sns, gcp-pubsub.
- Tests: offloading spec (2/2), full SQS publisher suite (37/37, backward-compat), SNS publishers (29 passed/1 skipped), PubSub publishers (12/12), core HandlerSpy (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)