### PR TITLE
fix: resolve consumer message schemas to the schema output type

### DIFF
--- a/packages/schemas/lib/events/eventTypes.ts
+++ b/packages/schemas/lib/events/eventTypes.ts
@@ -32,7 +32,8 @@ export type CommonEventDefinition = {
   tags?: readonly string[] // Free-form tags for the event
 }
 
-export type CommonEventDefinitionConsumerSchemaType<T extends CommonEventDefinition> = z.input<
+// Consumers receive messages already parsed by the consumer schema, hence the output type.
+export type CommonEventDefinitionConsumerSchemaType<T extends CommonEventDefinition> = z.output<
   T['consumerSchema']
 >
 

--- a/packages/schemas/lib/events/eventTypes.types.spec.ts
+++ b/packages/schemas/lib/events/eventTypes.types.spec.ts
@@ -1,0 +1,75 @@
+import { expectTypeOf } from 'vitest'
+import { z } from 'zod/v4'
+import { enrichMessageSchemaWithBase } from '../messages/baseMessageSchemas.ts'
+import type {
+  AnyEventHandler,
+  CommonEventDefinition,
+  CommonEventDefinitionConsumerSchemaType,
+  CommonEventDefinitionPublisherSchemaType,
+  SingleEventHandler,
+} from './eventTypes.ts'
+
+const myEvents = {
+  plainEvent: {
+    ...enrichMessageSchemaWithBase('entity.created', z.object({ name: z.string() })),
+  },
+  transformingEvent: {
+    ...enrichMessageSchemaWithBase(
+      'entity.updated',
+      z.object({
+        // Forward-compatible field: unknown values are dropped instead of failing validation
+        mode: z.preprocess(
+          (value) => (value === 'live' ? value : undefined),
+          z.literal('live').optional(),
+        ),
+      }),
+    ),
+  },
+} as const satisfies Record<string, CommonEventDefinition>
+
+describe('eventTypes', () => {
+  describe('CommonEventDefinitionConsumerSchemaType', () => {
+    it('resolves transformed fields to their output type, not their input type', () => {
+      type ConsumerMessage = CommonEventDefinitionConsumerSchemaType<
+        typeof myEvents.transformingEvent
+      >
+
+      // DomainEventEmitter hands handlers the event parsed by the schema
+      expectTypeOf<ConsumerMessage['payload']['mode']>().toEqualTypeOf<'live' | undefined>()
+    })
+  })
+
+  describe('CommonEventDefinitionPublisherSchemaType', () => {
+    it('keeps the input type for transformed fields', () => {
+      type PublisherMessage = CommonEventDefinitionPublisherSchemaType<
+        typeof myEvents.transformingEvent
+      >
+
+      // Publishers pass the raw payload that the schema parses on emit
+      expectTypeOf<PublisherMessage['payload']['mode']>().toBeUnknown()
+    })
+  })
+
+  describe('SingleEventHandler', () => {
+    it('receives the parsed event', () => {
+      type Handler = SingleEventHandler<[typeof myEvents.transformingEvent], 'entity.updated'>
+      type HandledEvent = Parameters<Handler['handleEvent']>[0]
+
+      expectTypeOf<HandledEvent['payload']['mode']>().toEqualTypeOf<'live' | undefined>()
+    })
+  })
+
+  describe('AnyEventHandler', () => {
+    it('receives the parsed event union', () => {
+      type Handler = AnyEventHandler<
+        [typeof myEvents.plainEvent, typeof myEvents.transformingEvent]
+      >
+      type HandledEvent = Parameters<Handler['handleEvent']>[0]
+
+      expectTypeOf<HandledEvent['type']>().toEqualTypeOf<'entity.created' | 'entity.updated'>()
+      expectTypeOf<
+        Extract<HandledEvent, { type: 'entity.updated' }>['payload']['mode']
+      >().toEqualTypeOf<'live' | undefined>()
+    })
+  })
+})

--- a/packages/schemas/lib/utils/messageTypeUtils.ts
+++ b/packages/schemas/lib/utils/messageTypeUtils.ts
@@ -3,9 +3,10 @@ import type { z } from 'zod/v4'
 import type { CommonEventDefinition } from '../events/eventTypes.ts'
 
 /**
- * Resolves schema of a consumer message for a given event definition
+ * Resolves schema of a consumer message for a given event definition.
+ * Consumers receive messages already parsed by the consumer schema, hence the output type.
  */
-export type ConsumerMessageSchema<MessageDefinitionType extends CommonEventDefinition> = z.input<
+export type ConsumerMessageSchema<MessageDefinitionType extends CommonEventDefinition> = z.output<
   MessageDefinitionType['consumerSchema']
 >
 
@@ -23,7 +24,8 @@ export type AllPublisherMessageSchemas<MessageDefinitionTypes extends CommonEven
   z.input<MessageDefinitionTypes[number]['publisherSchema']>
 
 /**
- * Resolves schema of all possible consumer messages for a given list of event definitions
+ * Resolves schema of all possible consumer messages for a given list of event definitions.
+ * Consumers receive messages already parsed by the consumer schema, hence the output type.
  */
 export type AllConsumerMessageSchemas<MessageDefinitionTypes extends CommonEventDefinition[]> =
-  z.input<MessageDefinitionTypes[number]['consumerSchema']>
+  z.output<MessageDefinitionTypes[number]['consumerSchema']>

--- a/packages/schemas/lib/utils/messageTypeUtils.types.spec.ts
+++ b/packages/schemas/lib/utils/messageTypeUtils.types.spec.ts
@@ -1,0 +1,78 @@
+import { expectTypeOf } from 'vitest'
+import { z } from 'zod/v4'
+import type { CommonEventDefinition } from '../events/eventTypes.ts'
+import { enrichMessageSchemaWithBase } from '../messages/baseMessageSchemas.ts'
+import type {
+  AllConsumerMessageSchemas,
+  ConsumerMessageSchema,
+  PublisherMessageSchema,
+} from './messageTypeUtils.ts'
+
+const SUPPORTED_MODES = ['status', 'value'] as const
+
+const myEvents = {
+  plainEvent: {
+    ...enrichMessageSchemaWithBase('entity.created', z.object({ name: z.string() })),
+  },
+  transformingEvent: {
+    ...enrichMessageSchemaWithBase(
+      'entity.updated',
+      z.object({
+        // Forward-compatible field: unknown values are dropped instead of failing validation
+        mode: z.preprocess(
+          (value) =>
+            typeof value === 'string' && (SUPPORTED_MODES as readonly string[]).includes(value)
+              ? value
+              : undefined,
+          z.enum(SUPPORTED_MODES).optional(),
+        ),
+      }),
+    ),
+  },
+} as const satisfies Record<string, CommonEventDefinition>
+
+describe('messageTypeUtils', () => {
+  describe('ConsumerMessageSchema', () => {
+    it('resolves to the parsed message type for transform-free schemas', () => {
+      type ConsumerMessage = ConsumerMessageSchema<typeof myEvents.plainEvent>
+
+      expectTypeOf<ConsumerMessage['type']>().toEqualTypeOf<'entity.created'>()
+      expectTypeOf<ConsumerMessage['payload']['name']>().toEqualTypeOf<string>()
+    })
+
+    it('resolves transformed fields to their output type, not their input type', () => {
+      type ConsumerMessage = ConsumerMessageSchema<typeof myEvents.transformingEvent>
+
+      // Consumers receive messages already parsed by the consumer schema, so the
+      // field is the preprocess output, not unknown (the input of any preprocess)
+      expectTypeOf<ConsumerMessage['payload']['mode']>().toEqualTypeOf<
+        'status' | 'value' | undefined
+      >()
+    })
+  })
+
+  describe('PublisherMessageSchema', () => {
+    it('resolves to the raw (pre-parse) message type', () => {
+      type PublisherMessage = PublisherMessageSchema<typeof myEvents.plainEvent>
+
+      expectTypeOf<PublisherMessage['payload']['name']>().toEqualTypeOf<string>()
+    })
+
+    it('keeps the input type for transformed fields', () => {
+      type PublisherMessage = PublisherMessageSchema<typeof myEvents.transformingEvent>
+
+      // Publishers pass the raw payload that the schema parses on emit
+      expectTypeOf<PublisherMessage['payload']['mode']>().toBeUnknown()
+    })
+  })
+
+  describe('AllConsumerMessageSchemas', () => {
+    it('resolves to the union of parsed message types', () => {
+      type SupportedMessages = AllConsumerMessageSchemas<
+        [typeof myEvents.plainEvent, typeof myEvents.transformingEvent]
+      >
+
+      expectTypeOf<SupportedMessages['type']>().toEqualTypeOf<'entity.created' | 'entity.updated'>()
+    })
+  })
+})

--- a/packages/schemas/lib/utils/messageTypeUtils.types.spec.ts
+++ b/packages/schemas/lib/utils/messageTypeUtils.types.spec.ts
@@ -1,17 +1,12 @@
 import { expectTypeOf } from 'vitest'
 import { z } from 'zod/v4'
-import type {
-  CommonEventDefinition,
-  CommonEventDefinitionConsumerSchemaType,
-} from '../events/eventTypes.ts'
+import type { CommonEventDefinition } from '../events/eventTypes.ts'
 import { enrichMessageSchemaWithBase } from '../messages/baseMessageSchemas.ts'
 import type {
   AllConsumerMessageSchemas,
   ConsumerMessageSchema,
   PublisherMessageSchema,
 } from './messageTypeUtils.ts'
-
-const SUPPORTED_MODES = ['status', 'value'] as const
 
 const myEvents = {
   plainEvent: {
@@ -23,11 +18,8 @@ const myEvents = {
       z.object({
         // Forward-compatible field: unknown values are dropped instead of failing validation
         mode: z.preprocess(
-          (value) =>
-            typeof value === 'string' && (SUPPORTED_MODES as readonly string[]).includes(value)
-              ? value
-              : undefined,
-          z.enum(SUPPORTED_MODES).optional(),
+          (value) => (value === 'live' ? value : undefined),
+          z.literal('live').optional(),
         ),
       }),
     ),
@@ -48,9 +40,7 @@ describe('messageTypeUtils', () => {
 
       // Consumers receive messages already parsed by the consumer schema, so the
       // field is the preprocess output, not unknown (the input of any preprocess)
-      expectTypeOf<ConsumerMessage['payload']['mode']>().toEqualTypeOf<
-        'status' | 'value' | undefined
-      >()
+      expectTypeOf<ConsumerMessage['payload']['mode']>().toEqualTypeOf<'live' | undefined>()
     })
   })
 
@@ -66,19 +56,6 @@ describe('messageTypeUtils', () => {
 
       // Publishers pass the raw payload that the schema parses on emit
       expectTypeOf<PublisherMessage['payload']['mode']>().toBeUnknown()
-    })
-  })
-
-  describe('CommonEventDefinitionConsumerSchemaType', () => {
-    it('resolves transformed fields to their output type, like ConsumerMessageSchema', () => {
-      type ConsumerMessage = CommonEventDefinitionConsumerSchemaType<
-        typeof myEvents.transformingEvent
-      >
-
-      // DomainEventEmitter hands handlers the event parsed by the schema
-      expectTypeOf<ConsumerMessage['payload']['mode']>().toEqualTypeOf<
-        'status' | 'value' | undefined
-      >()
     })
   })
 

--- a/packages/schemas/lib/utils/messageTypeUtils.types.spec.ts
+++ b/packages/schemas/lib/utils/messageTypeUtils.types.spec.ts
@@ -1,6 +1,9 @@
 import { expectTypeOf } from 'vitest'
 import { z } from 'zod/v4'
-import type { CommonEventDefinition } from '../events/eventTypes.ts'
+import type {
+  CommonEventDefinition,
+  CommonEventDefinitionConsumerSchemaType,
+} from '../events/eventTypes.ts'
 import { enrichMessageSchemaWithBase } from '../messages/baseMessageSchemas.ts'
 import type {
   AllConsumerMessageSchemas,
@@ -63,6 +66,19 @@ describe('messageTypeUtils', () => {
 
       // Publishers pass the raw payload that the schema parses on emit
       expectTypeOf<PublisherMessage['payload']['mode']>().toBeUnknown()
+    })
+  })
+
+  describe('CommonEventDefinitionConsumerSchemaType', () => {
+    it('resolves transformed fields to their output type, like ConsumerMessageSchema', () => {
+      type ConsumerMessage = CommonEventDefinitionConsumerSchemaType<
+        typeof myEvents.transformingEvent
+      >
+
+      // DomainEventEmitter hands handlers the event parsed by the schema
+      expectTypeOf<ConsumerMessage['payload']['mode']>().toEqualTypeOf<
+        'status' | 'value' | undefined
+      >()
     })
   })
 

--- a/packages/schemas/vitest.config.ts
+++ b/packages/schemas/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     watch: false,
     mockReset: true,
     pool: 'threads',
+    typecheck: {
+      enabled: true,
+      include: ['**/*.types.spec.ts'],
+    },
     coverage: {
       provider: 'v8',
       include: ['lib/**/*.ts'],


### PR DESCRIPTION
## Summary

`ConsumerMessageSchema` and `AllConsumerMessageSchemas` currently resolve to `z.input` of the consumer schema. However, consumers receive messages that have **already been parsed** by that schema (`parseMessage` calls `schema.parse(...)` before the handler is invoked), so the correct type is `z.output`.

For schemas without transforms `z.input` and `z.output` are identical, so this change is invisible to most consumers. They diverge once a schema uses `transform`/`preprocess` — for example a forward-compatible field that drops unknown enum variants instead of failing the whole event:

```ts
const PAYLOAD_SCHEMA = z.object({
  // ...
  context: z.preprocess(
    (v) => (isKnownContextType(v) ? v : undefined),
    CONTEXT_SCHEMA.optional(),
  ),
})
```

With `z.input`, the handler sees `context: unknown` (the input of a `preprocess` is always `unknown`), even though at runtime it receives the parsed `z.output` value. With this change the handler is typed with what it actually gets.

The same fix is applied to `CommonEventDefinitionConsumerSchemaType`, which had the same issue and types the handlers `DomainEventEmitter` invokes (`EventHandler`, `SingleEventHandler`, `AnyEventHandler`).

Publisher-side types (`PublisherMessageSchema`, `AllPublisherMessageSchemas`, `CommonEventDefinitionPublisherSchemaType`) intentionally stay `z.input`, since publishers pass the raw payload that `DomainEventEmitter.emit` parses.

## Note on impact

This is a type-level-only change (no runtime behavior). It may surface new type errors for downstream code that relied on the input type of transforming consumer schemas — those were previously typed incorrectly. A minor version bump is probably appropriate.

## Testing

- Type tests added (vitest `typecheck` enabled in `packages/schemas`, following the existing core/sns setup):
  - `lib/utils/messageTypeUtils.types.spec.ts` — `ConsumerMessageSchema` resolves transformed fields to their output type, `PublisherMessageSchema` keeps the raw input, `AllConsumerMessageSchemas` resolves the parsed union.
  - `lib/events/eventTypes.types.spec.ts` — same coverage for `CommonEventDefinitionConsumerSchemaType` / `CommonEventDefinitionPublisherSchemaType`, plus `SingleEventHandler` / `AnyEventHandler` receiving the parsed event.
  - `packages/core` `test/queues/HandlerContainer.types.spec.ts` — `MessageHandlerConfigBuilder.addConfig` infers the schema output as the handler message type (the path SNS/SQS consumer handlers go through).
- `packages/schemas`: `biome check` + `tsc` + `vitest` all pass
- `packages/core`, `packages/sns`, `packages/sqs` (including test consumers using `ConsumerMessageSchema`): `tsc --noEmit` passes

## Follow-up

An integration-level type test on `DomainEventEmitter` itself (asserting that `on`/`onAny` handlers and the `emit` return type see the parsed event) cannot be added in this PR: `packages/core` depends on the **published** `@message-queue-toolkit/schemas` (`^7.0.0`), so such a test only compiles once a version containing this fix is released and the dependency is bumped. The equivalent semantics are pinned in `eventTypes.types.spec.ts` via `SingleEventHandler`/`AnyEventHandler` (the exact types `on`/`onAny` use). Happy to add the `DomainEventEmitter` spec in a follow-up PR after the release.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected consumer message schema type validation to accurately reflect message parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
