### PR TITLE
chore: use caret ranges for zod peer dependencies

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,7 @@
 
 ### Description of Breaking Changes
 
-- **`zod` peer floor raised to `>=4.5.0`** in `core`, `kafka`, `sqs`, `sns`, `amqp` and `gcp-pubsub`. `zod` 4.5 is
+- **`zod` peer range narrowed to `^4.5.0`** in `core`, `kafka`, `sqs`, `sns`, `amqp` and `gcp-pubsub`. `zod` 4.5 is
   where ahead-of-time schema compilation landed, and the toolkit now relies on it. If you are still on `zod` 3.x or
   on 4.x below 4.5, upgrade `zod` before upgrading the toolkit, otherwise the install fails on an unsatisfiable
   peer range. `schemas` keeps its `>=3.25.67` floor: it uses nothing from 4.5.

--- a/packages/amqp/package.json
+++ b/packages/amqp/package.json
@@ -37,7 +37,7 @@
         "@message-queue-toolkit/core": ">=25.0.0",
         "@message-queue-toolkit/schemas": ">=7.0.0",
         "amqplib": "^2.0.1",
-        "zod": ">=4.5.0 <5.0.0"
+        "zod": "^4.5.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
         "toad-cache": "^3.7.4"
     },
     "peerDependencies": {
-        "zod": ">=4.5.0 <5.0.0"
+        "zod": "^4.5.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.8",

--- a/packages/gcp-pubsub/package.json
+++ b/packages/gcp-pubsub/package.json
@@ -33,7 +33,7 @@
     "peerDependencies": {
         "@google-cloud/pubsub": "^6.0.1",
         "@message-queue-toolkit/core": ">=26.0.0",
-        "zod": ">=4.5.0 <5.0.0"
+        "zod": "^4.5.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.8",

--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -58,7 +58,7 @@
     "peerDependencies": {
         "@message-queue-toolkit/core": ">=27.0.0",
         "@message-queue-toolkit/schemas": ">=7.0.0",
-        "zod": ">=4.5.0 <5.0.0"
+        "zod": "^4.5.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.8",

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -41,7 +41,7 @@
         "@message-queue-toolkit/core": ">=26.0.0",
         "@message-queue-toolkit/schemas": ">=7.0.0",
         "@message-queue-toolkit/sqs": ">=26.0.0",
-        "zod": ">=4.5.0 <5.0.0"
+        "zod": "^4.5.0"
     },
     "devDependencies": {
         "@aws-sdk/client-s3": "^3.1106.0",

--- a/packages/sqs/package.json
+++ b/packages/sqs/package.json
@@ -38,7 +38,7 @@
     "peerDependencies": {
         "@aws-sdk/client-sqs": "^3.1093.0",
         "@message-queue-toolkit/core": ">=26.0.0",
-        "zod": ">=4.5.0 <5.0.0"
+        "zod": "^4.5.0"
     },
     "devDependencies": {
         "@aws-sdk/client-s3": "^3.1106.0",


### PR DESCRIPTION
Addresses the open review thread on #560 ([discussion_r3912201573](https://github.com/kibertoad/message-queue-toolkit/pull/560#discussion_r3912201573)): express the `zod` peer range as `^4.5.0` instead of `>=4.5.0 <5.0.0`.

`^4.5.0` resolves to exactly `>=4.5.0 <5.0.0` for a non-zero major, so the set of accepted versions is unchanged — it is only the shorter, conventional spelling. It also matches how every other third-party peer in this repo is written: `amqplib` `^2.0.1`, `@google-cloud/pubsub` `^6.0.1`, `@aws-sdk/*` `^3.x`. Open-ended `>=` stays reserved for internal `@message-queue-toolkit/*` peers.

Applied to the six packages #560 touches: `core`, `amqp`, `sqs`, `sns`, `gcp-pubsub`, `kafka`. `UPGRADING.md` restates the range in the new form.

Left as-is deliberately:
- `schemas` keeps `zod` `>=3.25.67` — it spans majors 3 and 4, which a caret cannot express.
- `gcs-payload-store` keeps `@google-cloud/storage` `>=7.17.0 <9.0.0` — same reason, it spans 7.x and 8.x.

No lockfile change: workspace peer ranges are not recorded in `pnpm-lock.yaml`.

Merge this into `feat/precompile-schemas-zod-4.5` to fold it into #560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2mXyfXoNuiBNETTkU16QH

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2mXyfXoNuiBNETTkU16QH)_