### PR TITLE
fix: let callers hold a schema back from precompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,16 +225,37 @@ Then the message is automatically nacked without requeueing by the abstract cons
 
 `zod` can compile a schema ahead of time into a generated fast path, which parses several times faster than
 the interpreted parser. The toolkit does this for you: every schema you register is precompiled when it is
-registered, which covers `messageSchemas` on a publisher, the schemas passed to `MessageHandlerConfigBuilder`
-and `KafkaHandlerConfig`, the `schema` on a Kafka `TopicConfig`, and the event definitions given to an
-`EventRegistry`. There is nothing to opt into, and no reason to call `z.compile()` yourself before handing a
-schema over: compilation is memoized per schema, so registering the same one with a registry, a publisher and
-a consumer compiles it once.
+registered, which covers `messageSchemas` on a publisher, the schemas passed to `MessageHandlerConfig` and
+`MessageHandlerConfigBuilder` and `KafkaHandlerConfig`, the `schema` on a Kafka `TopicConfig`, and the event
+definitions given to an `EventRegistry`. There is nothing to opt into, and no reason to call `z.compile()`
+yourself before handing a schema over: compilation is memoized per schema, so registering the same one with a
+registry, a publisher and a consumer compiles it once.
 
 Precompiling returns a clone, so the schema instance the toolkit parses with is not the object you passed in.
-Your schema is left untouched, and parsing behavior is identical: a schema `zod` cannot compile (an async
-refinement, say) keeps using the regular parser. `precompileSchema` is exported from
-`@message-queue-toolkit/core` if you want the same treatment for a schema of your own.
+Your schema is left untouched, and a compiled schema accepts and rejects exactly what it accepted and rejected
+before: a schema `zod` cannot compile (an async refinement, say) keeps using the regular parser.
+`precompileSchema` is exported from `@message-queue-toolkit/core` if you want the same treatment for a schema
+of your own.
+
+One difference is worth knowing about if you write your own refinements or transforms. The compiled fast path
+signals rejection without building the error, leaving the interpreted parser to produce it, so a synchronous
+refinement or transform runs at most twice on a message that fails validation, and exactly once on a message
+that passes. Pure callbacks, which is what validation callbacks normally are, do not care. One with side
+effects does, and `excludeFromPrecompilation` holds such a schema back:
+
+```typescript
+import { excludeFromPrecompilation } from '@message-queue-toolkit/core'
+
+const MY_SCHEMA = excludeFromPrecompilation(
+  z.object({ id: z.string() }).refine((message) => {
+    auditRejectedIds(message.id) // runs once per parse, compiled or not
+    return isKnown(message.id)
+  }),
+)
+```
+
+Wrap the schema where you declare it, before anything registers it. The schema is then parsed as written
+wherever the toolkit uses it, giving up the speedup to keep the callback count exact.
 
 ### Barrier Pattern
 The barrier pattern facilitates the out-of-order message handling by retrying the message later if the system is not yet in the proper state to be able to process that message (e. g. some prerequisite messages have not yet arrived).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,10 +20,18 @@
 
 - **Registered schemas are precompiled automatically.** Publisher `messageSchemas`, handler schemas passed to
   `MessageHandlerConfigBuilder` / `MessageHandlerConfig` / `KafkaHandlerConfig`, the `schema` of a Kafka
-  `TopicConfig`, and the definitions given to `EventRegistry` are compiled when they are registered. Parsing
-  behavior does not change; only its speed does. Compilation is memoized per schema, so registering the same
-  schema with a registry, a publisher and a consumer compiles it once. Calling `z.compile()` yourself before
-  handing a schema over is no longer worth doing, but it is not an error either.
+  `TopicConfig`, and the definitions given to `EventRegistry` are compiled when they are registered. What a
+  schema accepts and rejects does not change; only the speed of deciding does. Compilation is memoized per
+  schema, so registering the same schema with a registry, a publisher and a consumer compiles it once. Calling
+  `z.compile()` yourself before handing a schema over is no longer worth doing, but it is not an error either.
+
+- **Your refinements and transforms can run twice on an invalid message.** The compiled fast path signals
+  rejection without building the error, leaving the interpreted parser to produce it, which replays synchronous
+  callbacks: a refinement or a transform runs exactly once on a message that passes validation and at most
+  twice on one that fails. This only matters for a callback with side effects, since a pure one returns the
+  same answer either way. `excludeFromPrecompilation(schema)`, exported from `@message-queue-toolkit/core`,
+  keeps a schema out of compilation so its callbacks run once per parse. Wrap the schema where you declare it,
+  before anything registers it, as registrations that already resolved a compiled clone keep it.
 
 
 ## Upgrading </br> `sqs` `25.x.x` -> `26.0.0` </br> `sns` `25.x.x` -> `26.0.0`

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -123,7 +123,11 @@ export { isRetryDateExceeded } from './utils/dateUtils.ts'
 export { isProduction, reloadConfig } from './utils/envUtils.ts'
 export { isShallowSubset, objectMatches } from './utils/matchUtils.ts'
 export { type ParseMessageResult, parseMessage } from './utils/parseUtils.ts'
-export { precompileEventDefinition, precompileSchema } from './utils/precompileUtils.ts'
+export {
+  excludeFromPrecompilation,
+  precompileEventDefinition,
+  precompileSchema,
+} from './utils/precompileUtils.ts'
 export { objectToBuffer } from './utils/queueUtils.ts'
 export {
   isStartupResourcePollingEnabled,

--- a/packages/core/lib/utils/precompileUtils.spec.ts
+++ b/packages/core/lib/utils/precompileUtils.spec.ts
@@ -4,7 +4,11 @@ import { EventRegistry } from '../events/EventRegistry.ts'
 import type { CommonEventDefinition } from '../events/eventTypes.ts'
 import { MessageHandlerConfigBuilder } from '../queues/HandlerContainer.ts'
 import { MessageSchemaContainer } from '../queues/MessageSchemaContainer.ts'
-import { precompileEventDefinition, precompileSchema } from './precompileUtils.ts'
+import {
+  excludeFromPrecompilation,
+  precompileEventDefinition,
+  precompileSchema,
+} from './precompileUtils.ts'
 
 const MESSAGE_SCHEMA = z.object({
   type: z.literal('message.a'),
@@ -130,5 +134,106 @@ describe('automatic precompilation', () => {
     expect(resolved.consumerSchema).toBe(precompileSchema(MESSAGE_SCHEMA))
     // The array the caller passed in is left as it was
     expect(registry.supportedEvents[0]).toBe(eventDefinition)
+  })
+})
+
+describe('excludeFromPrecompilation', () => {
+  it('hands the schema back and keeps it out of compilation', () => {
+    const schema = z.object({ payload: z.string() })
+
+    expect(excludeFromPrecompilation(schema)).toBe(schema)
+    expect(precompileSchema(schema)).toBe(schema)
+  })
+
+  it('holds even when the schema was already compiled', () => {
+    const schema = z.object({ payload: z.string() })
+    expect(precompileSchema(schema)).not.toBe(schema)
+
+    excludeFromPrecompilation(schema)
+
+    expect(precompileSchema(schema)).toBe(schema)
+  })
+
+  it('holds for a schema of an event definition', () => {
+    const consumerSchema = excludeFromPrecompilation(z.object({ payload: z.string() }))
+    const publisherSchema = z.object({ payload: z.string() })
+    const definition = { consumerSchema, publisherSchema } as unknown as CommonEventDefinition
+
+    const precompiled = precompileEventDefinition(definition)
+
+    expect(precompiled.consumerSchema).toBe(consumerSchema)
+    expect(precompiled.publisherSchema).not.toBe(publisherSchema)
+  })
+
+  it('holds for a schema registered on a message handler', () => {
+    const schema = excludeFromPrecompilation(
+      z.object({ type: z.literal('message.a'), payload: z.object({ name: z.string() }) }),
+    )
+
+    const configs = new MessageHandlerConfigBuilder<z.infer<typeof schema>, undefined>()
+      .addConfig(schema, () => Promise.resolve({ result: 'success' as const }))
+      .build()
+
+    expect(configs[0]?.schema).toBe(schema)
+  })
+})
+
+describe('callback invocation counts', () => {
+  const REJECTED_MESSAGE = { type: 'message.a', payload: { name: 'rejected' } }
+
+  const buildSchema = (onRefine: () => void) =>
+    z
+      .object({ type: z.literal('message.a'), payload: z.object({ name: z.string() }) })
+      .refine((message) => {
+        onRefine()
+        return message.payload.name !== 'rejected'
+      })
+
+  it('runs a refinement once on a message that validates', () => {
+    let calls = 0
+    const precompiled = precompileSchema(
+      buildSchema(() => {
+        calls++
+      }),
+    )
+
+    precompiled.parse(VALID_MESSAGE)
+
+    expect(calls).toBe(1)
+  })
+
+  it('runs a refinement no more than twice on a message that fails validation', () => {
+    // The compiled fast path signals rejection without building the error, so the interpreted
+    // parser produces it and replays the refinement. Twice is the ceiling the README promises,
+    // and the reason `excludeFromPrecompilation` exists.
+    let calls = 0
+    const precompiled = precompileSchema(
+      buildSchema(() => {
+        calls++
+      }),
+    )
+
+    expect(() => precompiled.parse(REJECTED_MESSAGE)).toThrow(z.ZodError)
+
+    expect(calls).toBeGreaterThanOrEqual(1)
+    expect(calls).toBeLessThanOrEqual(2)
+  })
+
+  it('runs a refinement on an excluded schema once per parse, whether it passes or fails', () => {
+    let calls = 0
+    const schema = precompileSchema(
+      excludeFromPrecompilation(
+        buildSchema(() => {
+          calls++
+        }),
+      ),
+    )
+
+    schema.parse(VALID_MESSAGE)
+    expect(calls).toBe(1)
+
+    calls = 0
+    expect(() => schema.parse(REJECTED_MESSAGE)).toThrow(z.ZodError)
+    expect(calls).toBe(1)
   })
 })

--- a/packages/core/lib/utils/precompileUtils.ts
+++ b/packages/core/lib/utils/precompileUtils.ts
@@ -19,15 +19,48 @@ const precompiledSchemas = new WeakMap<ZodType, ZodType>()
 const precompiledDefinitions = new WeakMap<CommonEventDefinition, CommonEventDefinition>()
 
 /**
+ * Schemas the caller has taken out of automatic precompilation, weak for the same reason as the
+ * memos above.
+ */
+const schemasExcludedFromPrecompilation = new WeakSet<ZodType>()
+
+/**
+ * Takes a schema out of automatic precompilation and hands it straight back, so the call can wrap
+ * a schema at the point where it is declared.
+ *
+ * Worth reaching for in one case: a refinement or a transform on the schema has side effects.
+ * Zod's compiled fast path signals rejection without building the error, leaving the interpreted
+ * parser to produce it, which can replay a synchronous refinement or transform on a message that
+ * fails validation. An excluded schema is parsed exactly as written, so every callback on it runs
+ * once per parse.
+ *
+ * Exclusion is checked ahead of the compilation memo, so it holds however the calls interleave.
+ * Registrations that already resolved a compiled clone keep the clone they hold, which is why the
+ * place to exclude a schema is where it is defined, before anything registers it.
+ */
+export function excludeFromPrecompilation<Schema extends ZodType>(schema: Schema): Schema {
+  schemasExcludedFromPrecompilation.add(schema)
+
+  return schema
+}
+
+/**
  * Builds an ahead-of-time compiled clone of the given schema, which parses noticeably faster than
  * the interpreted one. Callers of this toolkit never need to do this themselves: every schema
  * handed to a publisher, a consumer handler or an event definition is precompiled automatically.
  *
  * The original schema is left untouched, and repeat calls are free: the same schema always yields
  * the same clone, and passing a clone back returns it as is. A schema zod refuses to compile keeps
- * using the regular runtime parser, with no observable difference for the caller.
+ * using the regular runtime parser.
+ *
+ * A compiled clone accepts and rejects exactly what the schema it was built from does. The one
+ * difference is how often a callback of yours runs: a refinement or a transform can run a second
+ * time while the error for an invalid message is built. `excludeFromPrecompilation` opts a schema
+ * out when that is a problem.
  */
 export function precompileSchema<Schema extends ZodType>(schema: Schema): Schema {
+  if (schemasExcludedFromPrecompilation.has(schema)) return schema
+
   const memoized = precompiledSchemas.get(schema)
   if (memoized) return memoized as Schema
 
@@ -48,7 +81,7 @@ export function precompileSchema<Schema extends ZodType>(schema: Schema): Schema
  *
  * Both schemas are compiled, because both are read on a hot path: `DomainEventEmitter` parses with
  * `publisherSchema`, while `AbstractPublisherManager` registers `consumerSchema` as the schema its
- * publishers parse with.
+ * publishers parse with. Either of them can be held back with `excludeFromPrecompilation`.
  */
 export function precompileEventDefinition<Definition extends CommonEventDefinition>(
   definition: Definition,

--- a/packages/core/test/queues/MessageSchemaContainer.spec.ts
+++ b/packages/core/test/queues/MessageSchemaContainer.spec.ts
@@ -97,7 +97,7 @@ describe('MessageSchemaContainer', () => {
 
       // Valid type - returns the registered schema, precompiled
       const validResult = container.resolveSchema({ payload: 'test' }, { type: 'message.a' })
-      expect(validResult).toEqual({ result: precompileSchema(MESSAGE_SCHEMA_A) })
+      expect(validResult.result).toBe(precompileSchema(MESSAGE_SCHEMA_A))
 
       // Invalid type - resolver throws, error is returned
       const invalidResult = container.resolveSchema({ payload: 'test' }, { type: 'other.type' })


### PR DESCRIPTION
Addresses the two review threads left open on #560 when it merged.

### Refinements and transforms could run twice (`precompileUtils.ts`, major)

The finding is real. Measured on zod 4.5.4, a rejecting synchronous refinement on a compiled schema:

| | valid input | invalid input |
|---|---|---|
| interpreted | 1 call | 1 call |
| compiled | 1 call | **2 calls** |

The fast path signals rejection without building the error, so the interpreted parser produces it and replays the callback. Since #560 made precompilation automatic at every registration point, a caller with a side-effecting refinement had no way out.

The hazard is narrower than it first looks: it depends on where the fallback re-enters the schema. A `z.preprocess(toDatePreprocessor, z.date())` field nested in a message schema runs once even when a sibling field is invalid. And a pure callback, which is what a validation callback normally is, returns the same answer either way.

So rather than dropping automatic precompilation or heuristically refusing to compile any callback-bearing schema (which would silently cost the speedup for every schema using the toolkit's own recommended date preprocessor), this adds a per-schema opt-out:

```typescript
import { excludeFromPrecompilation } from '@message-queue-toolkit/core'

const MY_SCHEMA = excludeFromPrecompilation(
  z.object({ id: z.string() }).refine((message) => {
    auditRejectedIds(message.id) // runs once per parse, compiled or not
    return isKnown(message.id)
  }),
)
```

A `WeakSet` consulted ahead of the compilation memo, so exclusion holds however the calls interleave, and it covers event definition schemas too since `precompileEventDefinition` goes through `precompileSchema`.

Both docs claimed parsing behavior was identical ("parsing behavior does not change; only its speed does"). That was wrong, and both now state the invocation counts and point at the opt-out. Three tests pin the behavior: once per parse when the message passes, no more than twice when it fails, once either way when excluded. The ceiling is asserted as a range rather than exactly 2, so a future zod that avoids the replay does not fail CI for improving.

While in the same README paragraph, added `MessageHandlerConfig` to the list of registration points, which `UPGRADING.md` already listed.

### Identity assertion (`MessageSchemaContainer.spec.ts`, minor)

`toEqual({ result: ... })` deep-compares and would pass for a different compiled instance. Now `expect(validResult.result).toBe(precompileSchema(MESSAGE_SCHEMA_A))`, which is what the test is actually about.

### Verification

`packages/core`: 240 tests pass, `biome check` and `tsc` clean.
