### PR TITLE
feat(metrics)!: migrate from prom-client to @prometheus-io/client

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,13 +6,26 @@
 
 - **The Prometheus client peer dependency changed from `prom-client` to `@prometheus-io/client`.** `prom-client` is
   deprecated: it moved to the Prometheus org and is published as `@prometheus-io/client`, starting at version
-  `0.16.0`. The peer range is now `@prometheus-io/client >= 0.16.0`, so install it and drop `prom-client` unless
-  something else in your app still needs it. The runtime API is unchanged, so metric definitions, registries and
-  scrape endpoints keep working as they did.
+  `0.16.0`. The peer range is now `@prometheus-io/client >=0.16.0 <1`. The runtime API is unchanged, so metric
+  definitions, registries and scrape endpoints keep working as they did.
 
   ```sh
   npm uninstall prom-client
   npm install @prometheus-io/client
+  ```
+
+  If you keep `prom-client` installed because another integration still needs it, the two packages hold separate
+  default registries. The toolkit now registers its metrics on `@prometheus-io/client`'s `register`, so a `/metrics`
+  endpoint that serves `prom-client`'s `register` returns a scrape without them. Nothing throws, nothing is logged
+  and tests keep passing; the metrics are simply absent from the output. Serve the `@prometheus-io/client` registry
+  instead, or merge the two:
+
+  ```ts
+  import promClient from '@prometheus-io/client'
+  import legacyClient from 'prom-client'
+
+  const registry = promClient.Registry.merge([legacyClient.register, promClient.register])
+  app.get('/metrics', async (_req, res) => res.type(registry.contentType).send(await registry.metrics()))
   ```
 
   Type imports move with it:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,36 @@
 # Upgrading Guide
 
+## Upgrading </br> `metrics` `4.x.x` -> `5.0.0`
+
+### Description of Breaking Changes
+
+- **The Prometheus client peer dependency changed from `prom-client` to `@prometheus-io/client`.** `prom-client` is
+  deprecated: it moved to the Prometheus org and is published as `@prometheus-io/client`, starting at version
+  `0.16.0`. The peer range is now `@prometheus-io/client >= 0.16.0`, so install it and drop `prom-client` unless
+  something else in your app still needs it. The runtime API is unchanged, so metric definitions, registries and
+  scrape endpoints keep working as they did.
+
+  ```sh
+  npm uninstall prom-client
+  npm install @prometheus-io/client
+  ```
+
+  Type imports move with it:
+
+  ```diff
+  -import type { LabelValues } from 'prom-client'
+  +import type { LabelValues } from '@prometheus-io/client'
+  ```
+
+  If you pass a custom client as the second constructor argument of a `PrometheusMessageMetric` subclass, it must be
+  a `@prometheus-io/client` instance. Passing a `prom-client` one registers your metrics in a registry the rest of
+  your app no longer scrapes.
+
+  One typing detail to watch: `Metric`, `Counter`, `Histogram`, `Gauge` and `Summary` now default their label-name
+  parameter to `never` instead of `string`. A bare `Histogram` in your own code (a test double, for instance) is
+  `Histogram<never>` and no longer satisfies `Metric<string>`. Write `Histogram<string>` where you mean "any labels".
+
+
 ## Upgrading </br> `core` `26.x.x` -> `27.0.0` </br> `kafka` `xx.x.x` -> `xx.0.0` </br> `sqs` `xx.x.x` -> `xx.0.0` </br> `sns` `xx.x.x` -> `xx.0.0` </br> `amqp` `xx.x.x` -> `xx.0.0` </br> `gcp-pubsub` `xx.x.x` -> `xx.0.0`
 
 ### Description of Breaking Changes

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -5,7 +5,7 @@ This package contains utilities for collecting metrics in `@message-queue-toolki
 ## Installation
 
 ```sh
-npm install @message-queue-toolkit/metrics
+npm install @message-queue-toolkit/metrics @prometheus-io/client
 ```
 
 ## Overview
@@ -29,7 +29,7 @@ const service = new MyQueueService({ messageMetricsManager: metric })
 
 ## Prometheus metrics
 
-All Prometheus metrics use [prom-client](https://github.com/siimon/prom-client) under the hood.
+All Prometheus metrics use [@prometheus-io/client](https://github.com/prometheus/client_js) under the hood.
 
 ### Base parameters
 
@@ -43,7 +43,7 @@ All metrics accept `PrometheusMetricParams`:
 | `messageVersion` | `string \| (metadata) => string \| undefined` | no | Static version string or function to extract version from message metadata |
 | `labelNames` | `Labels[]` | when `Labels` is specified | Names of the custom labels to register. Must not overlap with `DefaultLabels` (`queue`, `messageType`, `version`, `result`) — TypeScript enforces this at compile time |
 
-An optional second argument accepts a custom `prom-client` instance (useful for testing or multi-registry setups).
+An optional second argument accepts a custom `@prometheus-io/client` instance (useful for testing or multi-registry setups).
 
 ---
 
@@ -87,7 +87,7 @@ Extend `PrometheusMessageTimeMetric` to add custom labels. Pass `labelNames` in 
 ```ts
 import { PrometheusMessageTimeMetric } from '@message-queue-toolkit/metrics'
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { LabelValues } from 'prom-client'
+import type { LabelValues } from '@prometheus-io/client'
 
 class MyProcessingTimeMetric extends PrometheusMessageTimeMetric<MyMessage, 'env'> {
   protected calculateObservedValue(metadata: ProcessedMessageMetadata<MyMessage>): number | null {
@@ -154,7 +154,7 @@ Extend `PrometheusMessageCounter` and implement `calculateCount`. Override `getL
 ```ts
 import { PrometheusMessageCounter } from '@message-queue-toolkit/metrics'
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { LabelValues } from 'prom-client'
+import type { LabelValues } from '@prometheus-io/client'
 
 class MyRegionCounter extends PrometheusMessageCounter<MyMessage, 'region'> {
   protected calculateCount(): number | null {

--- a/packages/metrics/lib/MessageMultiMetricManager.spec.ts
+++ b/packages/metrics/lib/MessageMultiMetricManager.spec.ts
@@ -1,5 +1,5 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import * as promClient from 'prom-client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it } from 'vitest'
 import { MessageMultiMetricManager } from './MessageMultiMetricManager.ts'
 import { PrometheusMessageLifetimeMetric } from './prometheus/metrics/message-time/PrometheusMessageLifetimeMetric.ts'

--- a/packages/metrics/lib/prometheus/PrometheusMessageMetric.ts
+++ b/packages/metrics/lib/prometheus/PrometheusMessageMetric.ts
@@ -1,6 +1,6 @@
 import type { MessageMetricsManager, ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { Metric } from 'prom-client'
-import promClient from 'prom-client'
+import type { Metric } from '@prometheus-io/client'
+import promClient from '@prometheus-io/client'
 import type { MessageVersionGeneratingFunction, PrometheusMetricParams } from './types.ts'
 
 /**w

--- a/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageCounter.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageCounter.spec.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { Counter, LabelValues } from 'prom-client'
-import * as promClient from 'prom-client'
+import type { Counter, LabelValues } from '@prometheus-io/client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it, vi } from 'vitest'
 import { PrometheusMessageCounter } from './PrometheusMessageCounter.ts'
 

--- a/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageCounter.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageCounter.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type promClient from 'prom-client'
-import type { Counter, LabelValues } from 'prom-client'
+import type promClient from '@prometheus-io/client'
+import type { Counter, LabelValues } from '@prometheus-io/client'
 import { PrometheusMessageMetric } from '../../PrometheusMessageMetric.ts'
 import type { DefaultLabels, PrometheusMetricParams } from '../../types.ts'
 

--- a/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageErrorCounter.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageErrorCounter.spec.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { Counter } from 'prom-client'
-import * as promClient from 'prom-client'
+import type { Counter } from '@prometheus-io/client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it, vi } from 'vitest'
 import { PrometheusMessageErrorCounter } from './PrometheusMessageErrorCounter.ts'
 

--- a/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageErrorCounter.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageErrorCounter.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type promClient from 'prom-client'
-import type { LabelValues } from 'prom-client'
+import type promClient from '@prometheus-io/client'
+import type { LabelValues } from '@prometheus-io/client'
 import type { PrometheusMetricParams } from '../../types.ts'
 import { PrometheusMessageCounter } from './PrometheusMessageCounter.ts'
 

--- a/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageResultCounter.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-error/PrometheusMessageResultCounter.spec.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { Counter } from 'prom-client'
-import * as promClient from 'prom-client'
+import type { Counter } from '@prometheus-io/client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it, vi } from 'vitest'
 import { PrometheusMessageResultCounter } from './PrometheusMessageResultCounter.ts'
 

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageLifetimeMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageLifetimeMetric.spec.ts
@@ -1,5 +1,5 @@
-import type { Histogram } from 'prom-client'
-import * as promClient from 'prom-client'
+import type { Histogram } from '@prometheus-io/client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it, vi } from 'vitest'
 import { PrometheusMessageLifetimeMetric } from './PrometheusMessageLifetimeMetric.ts'
 
@@ -20,7 +20,7 @@ describe('PrometheusMessageLifetimeMetric', () => {
       observe(labels: Record<string, string | number>, value: number) {
         observedValues.push({ labels, value })
       },
-    } as Histogram)
+    } as Histogram<string>)
 
     const metric = new PrometheusMessageLifetimeMetric<TestMessage>(
       {
@@ -71,7 +71,7 @@ describe('PrometheusMessageLifetimeMetric', () => {
       observe(labels: Record<string, string | number>, value: number) {
         observedValues.push({ labels, value })
       },
-    } as Histogram)
+    } as Histogram<string>)
 
     const metric = new PrometheusMessageLifetimeMetric<TestMessage>(
       {

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageProcessingTimeMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageProcessingTimeMetric.spec.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { Histogram } from 'prom-client'
-import * as promClient from 'prom-client'
+import type { Histogram } from '@prometheus-io/client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it, vi } from 'vitest'
 import { PrometheusMessageProcessingTimeMetric } from './PrometheusMessageProcessingTimeMetric.ts'
 
@@ -76,7 +76,7 @@ describe('MessageProcessingTimeMetric', () => {
       observe(labels: Record<string, string | number>, value: number) {
         observedValues.push({ labels, value })
       },
-    } as Histogram)
+    } as Histogram<string>)
 
     const metric = new PrometheusMessageProcessingTimeMetric<TestMessage>(
       {
@@ -127,7 +127,7 @@ describe('MessageProcessingTimeMetric', () => {
       observe(labels: Record<string, string | number>, value: number) {
         observedValues.push({ labels, value })
       },
-    } as Histogram)
+    } as Histogram<string>)
 
     const metric = new PrometheusMessageProcessingTimeMetric<TestMessage>(
       {

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageQueueTimeMetric.spec.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { Histogram } from 'prom-client'
-import * as promClient from 'prom-client'
+import type { Histogram } from '@prometheus-io/client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it, vi } from 'vitest'
 import { PrometheusMessageQueueTimeMetric } from './PrometheusMessageQueueTimeMetric.ts'
 
@@ -76,7 +76,7 @@ describe('PrometheusMessageQueueTimeMetric', () => {
       observe(labels: Record<string, string | number>, value: number) {
         observedValues.push({ labels, value })
       },
-    } as Histogram)
+    } as Histogram<string>)
 
     const metric = new PrometheusMessageQueueTimeMetric<TestMessage>(
       {
@@ -117,7 +117,7 @@ describe('PrometheusMessageQueueTimeMetric', () => {
       observe(labels: Record<string, string | number>, value: number) {
         observedValues.push({ labels, value })
       },
-    } as Histogram)
+    } as Histogram<string>)
 
     const metric = new PrometheusMessageQueueTimeMetric<TestMessage>(
       {
@@ -168,7 +168,7 @@ describe('PrometheusMessageQueueTimeMetric', () => {
       observe(labels: Record<string, string | number>, value: number) {
         observedValues.push({ labels, value })
       },
-    } as Histogram)
+    } as Histogram<string>)
 
     const metric = new PrometheusMessageQueueTimeMetric<TestMessage>(
       {

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageTimeMetric.spec.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageTimeMetric.spec.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type { Histogram, LabelValues } from 'prom-client'
-import * as promClient from 'prom-client'
+import type { Histogram, LabelValues } from '@prometheus-io/client'
+import * as promClient from '@prometheus-io/client'
 import { describe, expect, it, vi } from 'vitest'
 import { PrometheusMessageTimeMetric } from './PrometheusMessageTimeMetric.ts'
 
@@ -33,7 +33,7 @@ const mockObservedValues = () => {
     observe(labels: Record<string, string | number>, value: number) {
       observedValues.push({ labels, value })
     },
-  } as Histogram)
+  } as Histogram<string>)
   return observedValues
 }
 

--- a/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageTimeMetric.ts
+++ b/packages/metrics/lib/prometheus/metrics/message-time/PrometheusMessageTimeMetric.ts
@@ -1,6 +1,6 @@
 import type { ProcessedMessageMetadata } from '@message-queue-toolkit/core'
-import type promClient from 'prom-client'
-import type { Histogram, LabelValues } from 'prom-client'
+import type promClient from '@prometheus-io/client'
+import type { Histogram, LabelValues } from '@prometheus-io/client'
 import { PrometheusMessageMetric } from '../../PrometheusMessageMetric.ts'
 import type { DefaultLabels, PrometheusMetricParams } from '../../types.ts'
 

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -31,7 +31,7 @@
     },
     "peerDependencies": {
         "@message-queue-toolkit/core": ">=21.0.0",
-        "@prometheus-io/client": ">=0.16.0"
+        "@prometheus-io/client": ">=0.16.0 <1"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.11",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -31,7 +31,7 @@
     },
     "peerDependencies": {
         "@message-queue-toolkit/core": ">=21.0.0",
-        "prom-client": ">=15.0.0"
+        "@prometheus-io/client": ">=0.16.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,7 +286,7 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       '@prometheus-io/client':
-        specifier: '>=0.16.0'
+        specifier: '>=0.16.0 <1'
         version: 0.16.1
     devDependencies:
       '@biomejs/biome':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,9 +285,9 @@ importers:
       '@lokalise/universal-ts-utils':
         specifier: ^4.11.0
         version: 4.11.0
-      prom-client:
-        specifier: '>=15.0.0'
-        version: 15.1.3
+      '@prometheus-io/client':
+        specifier: '>=0.16.0'
+        version: 0.16.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.11
@@ -1073,6 +1073,10 @@ packages:
   '@platformatic/wasm-utils@0.2.1':
     resolution: {integrity: sha512-5rNl4h5n+hZG4LjiItQ7bVfHBqTypjldP46NXrOYW64cZr87ahngK1s9nEtCpByWg7WWjRLSxyCytgJK5gNdwQ==}
     engines: {node: '>= 22.19.0'}
+
+  '@prometheus-io/client@0.16.1':
+    resolution: {integrity: sha512-XkFPsGFGoSs/UMg/vh0QLDpanl/tsrOV5PLHdpGe8Ho+ir/Llhytr15j6y8ZwLrpIGzK9gTVVpIalA6C4UjUZw==}
+    engines: {node: ^22 || ^24 || >=26}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2159,11 +2163,6 @@ packages:
   process-warning@5.1.0:
     resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
 
-  prom-client@15.1.3:
-    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
-    engines: {node: ^16 || ^18 || >=20}
-    deprecated: prom-client has been replaced by @prometheus-io/client
-
   proto3-json-serializer@4.0.2:
     resolution: {integrity: sha512-VUQlb/J2WjOG8BKhdLwJUz+MKxSMtBGYh+TaNmRtiYVhlIzXjzeAGIx7gtc3lXlA2iURzfF2+cXaQvC2ofwzpg==}
     engines: {node: '>=22'}
@@ -3139,6 +3138,11 @@ snapshots:
   '@platformatic/wasm-utils@0.2.1':
     dependencies:
       '@platformatic/dynamic-buffer': 0.3.1
+
+  '@prometheus-io/client@0.16.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.3
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -4133,11 +4137,6 @@ snapshots:
   process-warning@4.0.1: {}
 
   process-warning@5.1.0: {}
-
-  prom-client@15.1.3:
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      tdigest: 0.1.3
 
   proto3-json-serializer@4.0.2:
     dependencies:


### PR DESCRIPTION
`prom-client` is deprecated on npm. It moved to the Prometheus org and is published as
[`@prometheus-io/client`](https://github.com/prometheus/client_js), starting at `0.16.0`.
`@message-queue-toolkit/metrics` now peers on that instead.

## What changed

- Peer dependency `prom-client >=15.0.0` → `@prometheus-io/client >=0.16.0`.
- All imports in `lib/` (and the specs) point at the new package. The runtime API is identical,
  so no metric definition, registry or scrape endpoint behaves differently.
- The new typings default the label-name parameter of `Metric`, `Counter`, `Histogram`, `Gauge`
  and `Summary` to `never` instead of `string`. A bare `Histogram` is therefore `Histogram<never>`
  and no longer satisfies the `Metric<string>` that `register.getSingleMetric()` returns, so the
  `Histogram` test doubles are cast to `Histogram<string>`.
- README and `UPGRADING.md` updated.

## Breaking

Consumers have to install `@prometheus-io/client` and drop `prom-client`, and move their own type
imports (`LabelValues` and friends) across. Anyone passing a custom client into a
`PrometheusMessageMetric` subclass must pass a `@prometheus-io/client` instance, otherwise the
metrics land in a registry the app no longer scrapes. Labelled as `major` for the `metrics` package
(4.4.3 → 5.0.0).

Worth knowing: `@prometheus-io/client` declares `engines: ^22 || ^24 || >=26`. CI already runs on
22 and 24, so nothing to do here, but consumers on Node 20 cannot take this upgrade.

## Verification

- `tsc --noEmit` and `tsc --project tsconfig.build.json` clean in `packages/metrics`.
- `vitest run`: 8 files, 29 tests passing.
- `biome check` clean on every changed file. (Three untouched files report CRLF formatting diffs in
  my local checkout only, a line-ending artifact of the Windows clone.)
- No `prom-client` left anywhere in the workspace or the lockfile.

https://claude.ai/code/session_01Aj3GUZFFGmEncpwkXP5baU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guidance for migrating from metrics 4.x to 5.0.
  * Updated installation instructions and examples to use `@prometheus-io/client`.

* **Compatibility**
  * Prometheus integrations now require `@prometheus-io/client` version 0.16.0 or later.
  * Custom Prometheus clients must use the supported client package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->