### PR TITLE
chore(metrics): trigger release

### DIFF
--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -223,3 +223,4 @@ const metricsManager = new MessageMultiMetricManager([
 
 const service = new MyQueueService({ messageMetricsManager: metricsManager })
 ```
+


### PR DESCRIPTION
The metrics package was skipped in the last release. The workflow bumped `packages/metrics/package.json` to 5.0.0, but 5.0.0 was already on npm from an earlier publish (2026-08-10), so the publish step saw the version as existing and skipped it.

Result: the `@prometheus-io/client` migration (#575) never reached npm. The published 5.0.0 still declares `prom-client` as a peer dependency, and `latest` points at 4.4.4.

This PR adds a trailing newline to `packages/metrics/README.md` so the paths filter in `publish.yml` puts metrics back into the release matrix.

Needs a version-bump label to actually publish. `release-same-version` would skip again, since 5.0.0 is taken.

https://claude.ai/code/session_01XJphWzj3io8FfcZSkLtLQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added trailing whitespace to the metrics package README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->