### PR TITLE
feat(schemas): allow object-or-union payloads in event definitions

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,26 @@
 # Upgrading Guide
 
+## Upgrading </br> `schemas` `8.0.0` -> `8.1.0`
+
+### Description of Changes
+
+- **The event payload schema constraint was relaxed to accept a union of object variants.**
+  `enrichMessageSchemaWithBase`, `enrichMessageSchemaWithBaseStrict`, `enrichEventSchemaWithBase`
+  and `getMessageType` previously required the payload schema to be a `ZodObject`. They now accept
+  any `EventPayloadSchema` — an object schema **or** a union of object schemas — while still
+  rejecting bare scalars (`z.string()`) and `z.any()`. This lets an event model a payload that is
+  either a single item or a batch of items.
+
+- **Type-argument arity dropped from three to two.** Relaxing the constraint removed the internal
+  `Y extends ZodRawShape` type parameter from those four functions. Call sites that rely on
+  inference — the overwhelmingly common case — are unaffected. Only code that passes **explicit**
+  type arguments needs updating:
+
+  ```diff
+  -enrichMessageSchemaWithBase<typeof PAYLOAD_SCHEMA, PayloadShape, 'my.event'>('my.event', PAYLOAD_SCHEMA)
+  +enrichMessageSchemaWithBase<typeof PAYLOAD_SCHEMA, 'my.event'>('my.event', PAYLOAD_SCHEMA)
+  ```
+
 ## Upgrading </br> `metrics` `4.x.x` -> `5.0.0`
 
 ### Description of Breaking Changes

--- a/packages/schemas/lib/events/baseEventSchemas.spec.ts
+++ b/packages/schemas/lib/events/baseEventSchemas.spec.ts
@@ -35,14 +35,4 @@ describe('enrichEventSchemaWithBase', () => {
     )
     expect(parsed.payload).toEqual({ projectId: 'p1', values: ['a', 'b'] })
   })
-
-  it('rejects a non-object payload schema', () => {
-    // @ts-expect-error payload must be an object or a union of objects, not a bare scalar
-    enrichEventSchemaWithBase('event.scalar', z.string())
-  })
-
-  it('rejects an `any` payload schema', () => {
-    // @ts-expect-error z.any() would satisfy the object constraint yet disable payload checking
-    enrichEventSchemaWithBase('event.any', z.any())
-  })
 })

--- a/packages/schemas/lib/events/baseEventSchemas.spec.ts
+++ b/packages/schemas/lib/events/baseEventSchemas.spec.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod/v4'
+import { enrichEventSchemaWithBase } from './baseEventSchemas.ts'
+
+const UNION_PAYLOAD_SCHEMA = z.union([
+  z.object({ projectId: z.string(), value: z.string() }),
+  z.object({ projectId: z.string(), values: z.array(z.string()) }),
+])
+
+const baseMessage = (type: string, payload: Record<string, unknown>) => ({
+  id: '1',
+  timestamp: new Date().toISOString(),
+  type,
+  payload,
+  metadata: {
+    schemaVersion: '1',
+    producedBy: 'USER_SERVICE',
+    originatedFrom: 'USER_SERVICE',
+    correlationId: 'c1',
+  },
+})
+
+describe('enrichEventSchemaWithBase', () => {
+  it('accepts a plain object payload schema', () => {
+    const schema = enrichEventSchemaWithBase('event.updated', z.object({ a: z.string() }))
+
+    const parsed = schema.consumerSchema.parse(baseMessage('event.updated', { a: 'x' }))
+    expect(parsed.payload).toEqual({ a: 'x' })
+  })
+
+  it('accepts a union payload schema', () => {
+    const schema = enrichEventSchemaWithBase('event.union', UNION_PAYLOAD_SCHEMA)
+
+    const parsed = schema.consumerSchema.parse(
+      baseMessage('event.union', { projectId: 'p1', values: ['a', 'b'] }),
+    )
+    expect(parsed.payload).toEqual({ projectId: 'p1', values: ['a', 'b'] })
+  })
+
+  it('rejects a non-object payload schema', () => {
+    // @ts-expect-error payload must be an object or a union of objects, not a bare scalar
+    enrichEventSchemaWithBase('event.scalar', z.string())
+  })
+
+  it('rejects an `any` payload schema', () => {
+    // @ts-expect-error z.any() would satisfy the object constraint yet disable payload checking
+    enrichEventSchemaWithBase('event.any', z.any())
+  })
+})

--- a/packages/schemas/lib/events/baseEventSchemas.ts
+++ b/packages/schemas/lib/events/baseEventSchemas.ts
@@ -1,11 +1,4 @@
-import type {
-  ZodISODateTime,
-  ZodLiteral,
-  ZodObject,
-  ZodOptional,
-  ZodRawShape,
-  ZodString,
-} from 'zod/v4'
+import type { ZodISODateTime, ZodLiteral, ZodObject, ZodOptional, ZodString } from 'zod/v4'
 import { z } from 'zod/v4'
 import { MESSAGE_DEDUPLICATION_OPTIONS_SCHEMA } from '../messages/messageDeduplicationSchemas.ts'
 
@@ -89,7 +82,33 @@ export type PublisherBaseEventType = z.output<typeof PUBLISHER_BASE_EVENT_SCHEMA
 export type CoreEventType = z.output<typeof CORE_EVENT_SCHEMA>
 export type GeneratedBaseEventType = z.output<typeof GENERATED_BASE_EVENT_SCHEMA>
 
-type ReturnType<T extends ZodObject<Y>, Y extends ZodRawShape, Z extends string> = {
+/**
+ * Schema allowed as an event/message payload: anything whose input and output are objects, which
+ * covers a plain object schema and a union of object variants (e.g. a single-item / multi-item
+ * shape). It stays object-based (a bare string/number payload is not allowed) while accepting
+ * unions. Defined via the input/output types (not `ZodObject | ZodUnion`) so `.extend` does not
+ * distribute over a type-level union and collapse it back to a plain object.
+ *
+ * Both the output AND input type parameters are pinned: leaving `Input` at its default `unknown`
+ * would widen `z.input<publisherSchema>['payload']` to `unknown`, dropping the object-payload
+ * guarantee for code written generically over CommonEventDefinition, and would let scalar-input
+ * transforms (e.g. `z.preprocess`) through.
+ */
+export type EventPayloadSchema = z.ZodType<Record<string, unknown>, Record<string, unknown>>
+
+type IsAny<T> = 0 extends 1 & T ? true : false
+
+/**
+ * A payload schema whose output is `any` (e.g. `z.any()`) satisfies EventPayloadSchema, because
+ * `any` is assignable to `Record<string, unknown>`, yet it silently disables payload type-checking
+ * for every handler and publisher of the event. Intersecting the payload parameter with this
+ * collapses it to `never` for such a schema, rejecting the call, while leaving real payloads
+ * (objects, unions of objects, transforms to objects) untouched.
+ */
+export type RejectAnyPayload<T extends EventPayloadSchema> =
+  IsAny<z.output<T>> extends true ? never : unknown
+
+type ReturnType<T extends EventPayloadSchema, Z extends string> = {
   consumerSchema: ZodObject<{
     id: ZodString
     timestamp: ZodISODateTime
@@ -105,11 +124,10 @@ type ReturnType<T extends ZodObject<Y>, Y extends ZodRawShape, Z extends string>
   }>
 }
 
-export function enrichEventSchemaWithBase<
-  T extends ZodObject<Y>,
-  Y extends ZodRawShape,
-  Z extends string,
->(type: Z, payloadSchema: T): ReturnType<T, Y, Z> {
+export function enrichEventSchemaWithBase<T extends EventPayloadSchema, Z extends string>(
+  type: Z,
+  payloadSchema: T & RejectAnyPayload<T>,
+): ReturnType<T, Z> {
   const baseSchema = z.object({
     type: z.literal(type),
     payload: payloadSchema,

--- a/packages/schemas/lib/events/baseEventSchemas.types.spec.ts
+++ b/packages/schemas/lib/events/baseEventSchemas.types.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod/v4'
+import type { EventPayloadSchema, RejectAnyPayload } from './baseEventSchemas.ts'
+
+const objectSchema = z.object({ a: z.string() })
+const unionSchema = z.union([z.object({ a: z.string() }), z.object({ b: z.number() })])
+
+describe('EventPayloadSchema', () => {
+  it('accepts an object payload schema', () => {
+    expectTypeOf<typeof objectSchema>().toExtend<EventPayloadSchema>()
+  })
+
+  it('accepts a union-of-objects payload schema', () => {
+    expectTypeOf<typeof unionSchema>().toExtend<EventPayloadSchema>()
+  })
+
+  it('does not accept a bare scalar payload schema', () => {
+    expectTypeOf<z.ZodString>().not.toExtend<EventPayloadSchema>()
+  })
+})
+
+describe('RejectAnyPayload', () => {
+  it('collapses an `any`-output payload schema to never', () => {
+    expectTypeOf<RejectAnyPayload<z.ZodAny>>().toBeNever()
+  })
+
+  it('leaves a real object payload schema untouched', () => {
+    expectTypeOf<RejectAnyPayload<typeof objectSchema>>().not.toBeNever()
+  })
+})

--- a/packages/schemas/lib/events/eventTypes.ts
+++ b/packages/schemas/lib/events/eventTypes.ts
@@ -1,21 +1,11 @@
 import { z } from 'zod/v4'
 
 import { MetadataObjectSchema } from '../messages/baseMessageSchemas.ts'
-import { CONSUMER_BASE_EVENT_SCHEMA, PUBLISHER_BASE_EVENT_SCHEMA } from './baseEventSchemas.ts'
-
-/**
- * Schema allowed as an event payload: anything whose input and output are objects, which covers
- * a plain object schema and a union of object variants (e.g. a single-item / multi-item shape).
- * It stays object-based (a bare string/number payload is not allowed) while accepting unions.
- * Defined via the input/output types (not `ZodObject | ZodUnion`) so `.extend` does not distribute
- * over a type-level union and collapse it back to a plain object.
- *
- * Both the output AND input type parameters are pinned: leaving `Input` at its default `unknown`
- * would widen `z.input<publisherSchema>['payload']` to `unknown`, dropping the object-payload
- * guarantee for code written generically over `CommonEventDefinition`, and would let
- * scalar-input transforms (e.g. `z.preprocess`) through.
- */
-export type EventPayloadSchema = z.ZodType<Record<string, unknown>, Record<string, unknown>>
+import {
+  CONSUMER_BASE_EVENT_SCHEMA,
+  type EventPayloadSchema,
+  PUBLISHER_BASE_EVENT_SCHEMA,
+} from './baseEventSchemas.ts'
 
 export type EventTypeNames<EventDefinition extends CommonEventDefinition> =
   CommonEventDefinitionConsumerSchemaType<EventDefinition>['type']

--- a/packages/schemas/lib/events/eventTypes.ts
+++ b/packages/schemas/lib/events/eventTypes.ts
@@ -4,13 +4,18 @@ import { MetadataObjectSchema } from '../messages/baseMessageSchemas.ts'
 import { CONSUMER_BASE_EVENT_SCHEMA, PUBLISHER_BASE_EVENT_SCHEMA } from './baseEventSchemas.ts'
 
 /**
- * Schema allowed as an event payload: anything whose output is an object, which covers a
- * plain object schema and a union of object variants (e.g. a single-item / multi-item shape).
+ * Schema allowed as an event payload: anything whose input and output are objects, which covers
+ * a plain object schema and a union of object variants (e.g. a single-item / multi-item shape).
  * It stays object-based (a bare string/number payload is not allowed) while accepting unions.
- * Defined via the output type (not `ZodObject | ZodUnion`) so `.extend` does not distribute
+ * Defined via the input/output types (not `ZodObject | ZodUnion`) so `.extend` does not distribute
  * over a type-level union and collapse it back to a plain object.
+ *
+ * Both the output AND input type parameters are pinned: leaving `Input` at its default `unknown`
+ * would widen `z.input<publisherSchema>['payload']` to `unknown`, dropping the object-payload
+ * guarantee for code written generically over `CommonEventDefinition`, and would let
+ * scalar-input transforms (e.g. `z.preprocess`) through.
  */
-export type EventPayloadSchema = z.ZodType<Record<string, unknown>>
+export type EventPayloadSchema = z.ZodType<Record<string, unknown>, Record<string, unknown>>
 
 export type EventTypeNames<EventDefinition extends CommonEventDefinition> =
   CommonEventDefinitionConsumerSchemaType<EventDefinition>['type']

--- a/packages/schemas/lib/events/eventTypes.ts
+++ b/packages/schemas/lib/events/eventTypes.ts
@@ -3,6 +3,15 @@ import { z } from 'zod/v4'
 import { MetadataObjectSchema } from '../messages/baseMessageSchemas.ts'
 import { CONSUMER_BASE_EVENT_SCHEMA, PUBLISHER_BASE_EVENT_SCHEMA } from './baseEventSchemas.ts'
 
+/**
+ * Schema allowed as an event payload: anything whose output is an object, which covers a
+ * plain object schema and a union of object variants (e.g. a single-item / multi-item shape).
+ * It stays object-based (a bare string/number payload is not allowed) while accepting unions.
+ * Defined via the output type (not `ZodObject | ZodUnion`) so `.extend` does not distribute
+ * over a type-level union and collapse it back to a plain object.
+ */
+export type EventPayloadSchema = z.ZodType<Record<string, unknown>>
+
 export type EventTypeNames<EventDefinition extends CommonEventDefinition> =
   CommonEventDefinitionConsumerSchemaType<EventDefinition>['type']
 
@@ -12,11 +21,11 @@ export function isCommonEventDefinition(entity: unknown): entity is CommonEventD
 
 const consumerSchema = CONSUMER_BASE_EVENT_SCHEMA.extend({
   metadata: MetadataObjectSchema,
-  payload: z.looseObject({}),
+  payload: z.looseObject({}) as EventPayloadSchema,
 })
 
 const publisherSchema = PUBLISHER_BASE_EVENT_SCHEMA.extend({
-  payload: z.looseObject({}),
+  payload: z.looseObject({}) as EventPayloadSchema,
 })
 
 export type CommonEventDefinition = {

--- a/packages/schemas/lib/messages/baseMessageSchemas.spec.ts
+++ b/packages/schemas/lib/messages/baseMessageSchemas.spec.ts
@@ -3,9 +3,19 @@ import { z } from 'zod/v4'
 import type { SnsAwareEventDefinition } from '../vendors/snsSchemas.ts'
 import { enrichMessageSchemaWithBase } from './baseMessageSchemas.ts'
 
+const UNION_PAYLOAD_SCHEMA = z.union([
+  z.object({ projectId: z.string(), value: z.string() }),
+  z.object({ projectId: z.string(), values: z.array(z.string()) }),
+])
+
 const myEvents = {
   myEvent: {
     ...enrichMessageSchemaWithBase('user.updated', z.object({})),
+    snsTopic: 'user',
+    producedBy: ['USER_SERVICE'],
+  },
+  myUnionEvent: {
+    ...enrichMessageSchemaWithBase('user.union_updated', UNION_PAYLOAD_SCHEMA),
     snsTopic: 'user',
     producedBy: ['USER_SERVICE'],
   },
@@ -14,5 +24,28 @@ const myEvents = {
 describe('base message schemas', () => {
   it('message satisfies SnsAwareEventDefinition', () => {
     expectTypeOf(myEvents.myEvent).toExtend<SnsAwareEventDefinition>()
+  })
+
+  it('rejects a non-object payload schema', () => {
+    // @ts-expect-error payload must be an object or a union of objects, not a bare scalar
+    enrichMessageSchemaWithBase('user.updated', z.string())
+  })
+
+  it('accepts a union payload schema', () => {
+    expectTypeOf(myEvents.myUnionEvent).toExtend<SnsAwareEventDefinition>()
+
+    const parsed = myEvents.myUnionEvent.consumerSchema.parse({
+      id: '1',
+      timestamp: new Date().toISOString(),
+      type: 'user.union_updated',
+      payload: { projectId: 'p1', values: ['a', 'b'] },
+      metadata: {
+        schemaVersion: '1',
+        producedBy: 'USER_SERVICE',
+        originatedFrom: 'USER_SERVICE',
+        correlationId: 'c1',
+      },
+    })
+    expect(parsed.payload).toEqual({ projectId: 'p1', values: ['a', 'b'] })
   })
 })

--- a/packages/schemas/lib/messages/baseMessageSchemas.spec.ts
+++ b/packages/schemas/lib/messages/baseMessageSchemas.spec.ts
@@ -31,6 +31,11 @@ describe('base message schemas', () => {
     enrichMessageSchemaWithBase('user.updated', z.string())
   })
 
+  it('rejects an `any` payload schema', () => {
+    // @ts-expect-error z.any() would satisfy the object constraint yet disable payload checking
+    enrichMessageSchemaWithBase('user.updated', z.any())
+  })
+
   it('accepts a union payload schema', () => {
     expectTypeOf(myEvents.myUnionEvent).toExtend<SnsAwareEventDefinition>()
 

--- a/packages/schemas/lib/messages/baseMessageSchemas.spec.ts
+++ b/packages/schemas/lib/messages/baseMessageSchemas.spec.ts
@@ -26,19 +26,28 @@ describe('base message schemas', () => {
     expectTypeOf(myEvents.myEvent).toExtend<SnsAwareEventDefinition>()
   })
 
-  it('rejects a non-object payload schema', () => {
-    // @ts-expect-error payload must be an object or a union of objects, not a bare scalar
-    enrichMessageSchemaWithBase('user.updated', z.string())
-  })
+  it('accepts a payload schema that transforms one object into another', () => {
+    const schema = enrichMessageSchemaWithBase(
+      'user.updated',
+      z.object({ a: z.string() }).transform((v) => ({ ...v, extra: 1 })),
+    )
 
-  it('rejects an `any` payload schema', () => {
-    // @ts-expect-error z.any() would satisfy the object constraint yet disable payload checking
-    enrichMessageSchemaWithBase('user.updated', z.any())
+    const parsed = schema.consumerSchema.parse({
+      id: '1',
+      timestamp: new Date().toISOString(),
+      type: 'user.updated',
+      payload: { a: 'x' },
+      metadata: {
+        schemaVersion: '1',
+        producedBy: 'USER_SERVICE',
+        originatedFrom: 'USER_SERVICE',
+        correlationId: 'c1',
+      },
+    })
+    expect(parsed.payload).toEqual({ a: 'x', extra: 1 })
   })
 
   it('accepts a union payload schema', () => {
-    expectTypeOf(myEvents.myUnionEvent).toExtend<SnsAwareEventDefinition>()
-
     const parsed = myEvents.myUnionEvent.consumerSchema.parse({
       id: '1',
       timestamp: new Date().toISOString(),

--- a/packages/schemas/lib/messages/baseMessageSchemas.ts
+++ b/packages/schemas/lib/messages/baseMessageSchemas.ts
@@ -78,17 +78,23 @@ export type SchemaMetadata = {
   description: string
 }
 
+type IsAny<T> = 0 extends 1 & T ? true : false
+type RejectAnyPayload<T extends EventPayloadSchema> =
+  IsAny<z.output<T>> extends true ? never : unknown
+
 export function enrichMessageSchemaWithBaseStrict<T extends EventPayloadSchema, Z extends string>(
   type: Z,
-  payloadSchema: T,
+  payloadSchema: T & RejectAnyPayload<T>,
   schemaMetadata: SchemaMetadata,
 ): ReturnType<T, Z> {
-  return enrichMessageSchemaWithBase(type, payloadSchema, schemaMetadata)
+  // Explicit type args: payloadSchema is already `T & RejectAnyPayload<T>` here, so let inference
+  // reuse T instead of re-applying RejectAnyPayload to the intersection.
+  return enrichMessageSchemaWithBase<T, Z>(type, payloadSchema, schemaMetadata)
 }
 
 export function enrichMessageSchemaWithBase<T extends EventPayloadSchema, Z extends string>(
   type: Z,
-  payloadSchema: T,
+  payloadSchema: T & RejectAnyPayload<T>,
   schemaMetadata?: Partial<SchemaMetadata>,
 ): ReturnType<T, Z> {
   const baseSchema = z.object({

--- a/packages/schemas/lib/messages/baseMessageSchemas.ts
+++ b/packages/schemas/lib/messages/baseMessageSchemas.ts
@@ -4,7 +4,6 @@ import z, {
   type ZodNullable,
   type ZodObject,
   type ZodOptional,
-  type ZodRawShape,
   type ZodString,
 } from 'zod/v4'
 import {
@@ -15,7 +14,7 @@ import {
   PUBLISHER_BASE_EVENT_SCHEMA,
   type PUBLISHER_MESSAGE_METADATA_SCHEMA,
 } from '../events/baseEventSchemas.ts'
-import type { CommonEventDefinition } from '../events/eventTypes.ts'
+import type { CommonEventDefinition, EventPayloadSchema } from '../events/eventTypes.ts'
 import type { MESSAGE_DEDUPLICATION_OPTIONS_SCHEMA } from './messageDeduplicationSchemas.ts'
 
 export const CONSUMER_BASE_MESSAGE_SCHEMA = CONSUMER_BASE_EVENT_SCHEMA
@@ -46,7 +45,7 @@ export const MetadataObjectSchema = z.object({
   correlationId: z.string(),
 })
 
-type ReturnType<T extends ZodObject<Y>, Y extends ZodRawShape, Z extends string> = {
+type ReturnType<T extends EventPayloadSchema, Z extends string> = {
   consumerSchema: ZodObject<{
     id: ZodString
     timestamp: ZodISODateTime
@@ -79,19 +78,19 @@ export type SchemaMetadata = {
   description: string
 }
 
-export function enrichMessageSchemaWithBaseStrict<
-  T extends ZodObject<Y>,
-  Y extends ZodRawShape,
-  Z extends string,
->(type: Z, payloadSchema: T, schemaMetadata: SchemaMetadata): ReturnType<T, Y, Z> {
+export function enrichMessageSchemaWithBaseStrict<T extends EventPayloadSchema, Z extends string>(
+  type: Z,
+  payloadSchema: T,
+  schemaMetadata: SchemaMetadata,
+): ReturnType<T, Z> {
   return enrichMessageSchemaWithBase(type, payloadSchema, schemaMetadata)
 }
 
-export function enrichMessageSchemaWithBase<
-  T extends ZodObject<Y>,
-  Y extends ZodRawShape,
-  Z extends string,
->(type: Z, payloadSchema: T, schemaMetadata?: Partial<SchemaMetadata>): ReturnType<T, Y, Z> {
+export function enrichMessageSchemaWithBase<T extends EventPayloadSchema, Z extends string>(
+  type: Z,
+  payloadSchema: T,
+  schemaMetadata?: Partial<SchemaMetadata>,
+): ReturnType<T, Z> {
   const baseSchema = z.object({
     type: z.literal(type),
     payload: payloadSchema,
@@ -111,8 +110,8 @@ export function enrichMessageSchemaWithBase<
   }
 }
 
-export function getMessageType<T extends ZodObject<Y>, Y extends ZodRawShape, Z extends string>(
-  richMessageSchema: ReturnType<T, Y, Z>,
+export function getMessageType<T extends EventPayloadSchema, Z extends string>(
+  richMessageSchema: ReturnType<T, Z>,
 ): Z {
   return richMessageSchema.consumerSchema.shape.type.value
 }

--- a/packages/schemas/lib/messages/baseMessageSchemas.ts
+++ b/packages/schemas/lib/messages/baseMessageSchemas.ts
@@ -9,12 +9,14 @@ import z, {
 import {
   CONSUMER_BASE_EVENT_SCHEMA,
   type CONSUMER_MESSAGE_METADATA_SCHEMA,
+  type EventPayloadSchema,
   GENERATED_BASE_EVENT_SCHEMA,
   OPTIONAL_GENERATED_BASE_EVENT_SCHEMA,
   PUBLISHER_BASE_EVENT_SCHEMA,
   type PUBLISHER_MESSAGE_METADATA_SCHEMA,
+  type RejectAnyPayload,
 } from '../events/baseEventSchemas.ts'
-import type { CommonEventDefinition, EventPayloadSchema } from '../events/eventTypes.ts'
+import type { CommonEventDefinition } from '../events/eventTypes.ts'
 import type { MESSAGE_DEDUPLICATION_OPTIONS_SCHEMA } from './messageDeduplicationSchemas.ts'
 
 export const CONSUMER_BASE_MESSAGE_SCHEMA = CONSUMER_BASE_EVENT_SCHEMA
@@ -77,10 +79,6 @@ type ReturnType<T extends EventPayloadSchema, Z extends string> = {
 export type SchemaMetadata = {
   description: string
 }
-
-type IsAny<T> = 0 extends 1 & T ? true : false
-type RejectAnyPayload<T extends EventPayloadSchema> =
-  IsAny<z.output<T>> extends true ? never : unknown
 
 export function enrichMessageSchemaWithBaseStrict<T extends EventPayloadSchema, Z extends string>(
   type: Z,

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@message-queue-toolkit/schemas",
-    "version": "7.2.0",
+    "version": "8.0.0",
     "private": false,
     "license": "MIT",
     "description": "Useful utilities, interfaces and base classes for message queue handling. Supports AMQP and SQS with a common abstraction on top currently",


### PR DESCRIPTION
## What

`enrichMessageSchemaWithBase` / `enrichMessageSchemaWithBaseStrict` constrained the payload schema to a `ZodObject`, so an event payload could not be modelled as a **union of object variants** (e.g. a single-item / multi-item shape).

This relaxes the constraint to a new `EventPayloadSchema = z.ZodType<Record<string, unknown>>`:

- a plain object schema — still accepted
- a union of object schemas — now accepted
- a bare scalar payload (`z.string()`, `z.number()`, …) — still rejected

`CommonEventDefinition`'s sentinel payload is widened the same way so union-payload events still satisfy it. Defining the type via the *output* (`Record<string, unknown>`) rather than `ZodObject | ZodUnion` avoids `.extend` distributing over a type-level union and collapsing it back to a plain object.

## Why

Enables events that carry either one item or many (union of the current single shape and an array-of-items shape) without abandoning the object-based payload guarantee.

## Tests

`baseMessageSchemas.spec.ts`:
- union payload accepted, with a real `consumerSchema.parse` of a multi-item message
- scalar payload rejected (`@ts-expect-error`)

`tsc --noEmit` clean, full schemas suite green (24/24).

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event and message schema helpers now support unions of object payload variants and object-producing transforms.
  * Unsupported scalar payloads and schemas with unrestricted outputs are rejected during validation.

* **Documentation**
  * Added upgrade guidance for the expanded payload support and updated function type-argument requirements.

* **Tests**
  * Added coverage for union payloads, transformed payloads, validation rules, and runtime parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->