### PR TITLE
chore: MQT core supports schemas 8

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@lokalise/node-core": "^14.9.1",
         "@lokalise/universal-ts-utils": "^4.11.0",
-        "@message-queue-toolkit/schemas": "^7.2.0",
+        "@message-queue-toolkit/schemas": ">=7.2.0 <9.0.0",
         "dot-prop": "^10.2.0",
         "fast-equals": "^6.0.2",
         "json-stream-stringify": "^3.1.7",
@@ -41,6 +41,7 @@
         "@biomejs/biome": "^2.5.11",
         "@lokalise/biome-config": "^3.1.1",
         "@lokalise/tsconfig": "^5.0.0",
+        "@message-queue-toolkit/schemas": "workspace:*",
         "@types/node": "^26.4.1",
         "@types/tmp": "^0.2.6",
         "@vitest/coverage-v8": "^4.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       '@message-queue-toolkit/schemas':
-        specifier: ^7.2.0
+        specifier: '>=7.2.0 <9.0.0'
         version: 7.2.0(zod@4.5.4)
       dot-prop:
         specifier: ^10.2.0
@@ -1218,6 +1218,7 @@ packages:
   '@smithy/node-http-handler@4.12.0':
     resolution: {integrity: sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Depreacted due to a memory leak issue https://github.com/smithy-lang/smithy-typescript/issues/2258
 
   '@smithy/signature-v4@5.7.3':
     resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Improved compatibility with supported message schema versions.
- **Chores**
  - Updated package configuration to support a broader range of schema releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->