### PR TITLE
DomainEventEmitter dispose improvements

### DIFF
--- a/packages/core/lib/events/DomainEventEmitter.spec.ts
+++ b/packages/core/lib/events/DomainEventEmitter.spec.ts
@@ -461,9 +461,9 @@ describe('DomainEventEmitter', () => {
 
       await eventEmitter.dispose()
 
-      await expect(eventEmitter.emit(TestEvents.created, createdEventPayload)).rejects.toMatchObject(
-        { errorCode: 'EVENT_EMITTER_DISPOSED' },
-      )
+      await expect(
+        eventEmitter.emit(TestEvents.created, createdEventPayload),
+      ).rejects.toMatchObject({ errorCode: 'EVENT_EMITTER_DISPOSED' })
       expect(fakeListener.receivedEvents).toHaveLength(0)
     })
 

--- a/packages/core/lib/events/DomainEventEmitter.spec.ts
+++ b/packages/core/lib/events/DomainEventEmitter.spec.ts
@@ -455,14 +455,40 @@ describe('DomainEventEmitter', () => {
       expect(fakeListener2.receivedEvents[0]).toMatchObject(expectedUpdatedPayload)
     })
 
-    it('after dispose handlers are not called', async () => {
+    it('rejects emitting after dispose instead of dropping the event', async () => {
       const fakeListener = new FakeListener()
       eventEmitter.onAny(fakeListener)
 
       await eventEmitter.dispose()
 
-      await eventEmitter.emit(TestEvents.created, createdEventPayload)
+      await expect(eventEmitter.emit(TestEvents.created, createdEventPayload)).rejects.toMatchObject(
+        { errorCode: 'EVENT_EMITTER_DISPOSED' },
+      )
       expect(fakeListener.receivedEvents).toHaveLength(0)
+    })
+
+    it('awaits background handlers that register while draining', async () => {
+      // The chaining listener emits a follow-up event from within a background handler, so the
+      // follow-up's own background handler only registers once dispose() started draining.
+      const chainedListener = new FakeListener(100)
+      eventEmitter.onMany(['entity.updated'], chainedListener, true)
+      eventEmitter.onMany(
+        ['entity.created'],
+        {
+          eventHandlerId: 'ChainingListener',
+          handleEvent: async () => {
+            await eventEmitter.emit(TestEvents.updated, updatedEventPayload)
+          },
+        },
+        true,
+      )
+
+      await eventEmitter.emit(TestEvents.created, createdEventPayload)
+      expect(chainedListener.receivedEvents).toHaveLength(0)
+
+      await eventEmitter.dispose()
+
+      expect(chainedListener.receivedEvents).toHaveLength(1)
     })
   })
 })

--- a/packages/core/lib/events/DomainEventEmitter.spec.ts
+++ b/packages/core/lib/events/DomainEventEmitter.spec.ts
@@ -490,5 +490,32 @@ describe('DomainEventEmitter', () => {
 
       expect(chainedListener.receivedEvents).toHaveLength(1)
     })
+
+    it('awaits an event still running its foreground handlers when draining starts', async () => {
+      // An event is only tracked as an in-progress background handler once its foreground handlers
+      // have completed, so disposal starting mid-foreground must not miss it.
+      const backgroundListener = new FakeListener(100)
+      eventEmitter.onMany(['entity.created'], backgroundListener, true)
+
+      let releaseForegroundHandler: () => void = () => {}
+      const foregroundHandlerGate = new Promise<void>((resolve) => {
+        releaseForegroundHandler = resolve
+      })
+      eventEmitter.onMany(['entity.created'], {
+        eventHandlerId: 'GatedForegroundListener',
+        handleEvent: () => foregroundHandlerGate,
+      })
+
+      // Not awaited: emit() only resolves once the gated foreground handler is released
+      const emitPromise = eventEmitter.emit(TestEvents.created, createdEventPayload)
+      expect(backgroundListener.receivedEvents).toHaveLength(0)
+
+      const disposePromise = eventEmitter.dispose()
+      releaseForegroundHandler()
+      await disposePromise
+
+      expect(backgroundListener.receivedEvents).toHaveLength(1)
+      await emitPromise
+    })
   })
 })

--- a/packages/core/lib/events/DomainEventEmitter.ts
+++ b/packages/core/lib/events/DomainEventEmitter.ts
@@ -21,6 +21,13 @@ import type {
   SingleEventHandler,
 } from './eventTypes.ts'
 
+/**
+ * Upper bound on how many times dispose() re-checks for background handlers that registered while
+ * it was draining. Each pass only continues if the previous one found work, so this is a guard
+ * against endless event chains rather than a limit on normal shutdowns.
+ */
+const MAX_DISPOSE_DRAIN_PASSES = 10
+
 export type DomainEventEmitterDependencies<SupportedEvents extends CommonEventDefinition[]> = {
   eventRegistry: EventRegistry<SupportedEvents>
   metadataFiller: MetadataFiller
@@ -49,6 +56,7 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
     Handlers<EventHandler<CommonEventDefinitionConsumerSchemaType<SupportedEvents[number]>>>
   >
   private readonly inProgressBackgroundHandlerByEventId: Map<string, Promise<void>>
+  private isDisposed = false
 
   constructor(
     deps: DomainEventEmitterDependencies<SupportedEvents>,
@@ -80,8 +88,33 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
     return this._handlerSpy
   }
 
+  /**
+   * Waits for background handlers to settle, then stops accepting events.
+   *
+   * Background handlers can register while the drain is already running, either because their
+   * `emit()` was still awaiting foreground handlers when the drain started, or because a background
+   * handler emits an event of its own. A single pass over the map would miss those, so we keep
+   * draining until it stays empty, bounded so that an endless chain of events cannot hold shutdown
+   * open forever.
+   */
   public async dispose(): Promise<void> {
-    await Promise.all(this.inProgressBackgroundHandlerByEventId.values())
+    for (let pass = 0; pass < MAX_DISPOSE_DRAIN_PASSES; pass++) {
+      if (this.inProgressBackgroundHandlerByEventId.size === 0) break
+
+      await Promise.all(this.inProgressBackgroundHandlerByEventId.values())
+    }
+
+    if (this.inProgressBackgroundHandlerByEventId.size > 0) {
+      this.logger.error(
+        { pendingBackgroundHandlers: this.inProgressBackgroundHandlerByEventId.size },
+        `Background event handlers still pending after ${MAX_DISPOSE_DRAIN_PASSES} drain passes, giving up on them`,
+      )
+    }
+
+    // Set before clearing the handlers, so that an event emitted from this point on fails loudly
+    // rather than finding an empty handler map and being silently discarded.
+    this.isDisposed = true
+
     this.inProgressBackgroundHandlerByEventId.clear()
     this.eventHandlerMap.clear()
     this._handlerSpy?.clear()
@@ -97,6 +130,19 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
       throw new InternalError({
         errorCode: 'UNKNOWN_EVENT',
         message: `Unknown event ${eventTypeName}`,
+      })
+    }
+
+    /*
+			A disposed emitter has no handlers left, so the event would reach neither its listeners nor
+			any listener that forwards it onwards (for example to a message broker). Failing here lets the
+			caller fail and be retried, instead of completing successfully while its event silently went nowhere.
+		*/
+    if (this.isDisposed) {
+      throw new InternalError({
+        errorCode: 'EVENT_EMITTER_DISPOSED',
+        message: `Cannot emit event ${eventTypeName}, emitter is already disposed`,
+        details: { eventTypeName },
       })
     }
 

--- a/packages/core/lib/events/DomainEventEmitter.ts
+++ b/packages/core/lib/events/DomainEventEmitter.ts
@@ -22,9 +22,9 @@ import type {
 } from './eventTypes.ts'
 
 /**
- * Upper bound on how many times dispose() re-checks for background handlers that registered while
- * it was draining. Each pass only continues if the previous one found work, so this is a guard
- * against endless event chains rather than a limit on normal shutdowns.
+ * Upper bound on how many times dispose() re-checks for event dispatches that registered while it
+ * was draining. Each pass only continues if the previous one found work, so this is a guard against
+ * endless event chains rather than a limit on normal shutdowns.
  */
 const MAX_DISPOSE_DRAIN_PASSES = 10
 
@@ -55,6 +55,7 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
     string,
     Handlers<EventHandler<CommonEventDefinitionConsumerSchemaType<SupportedEvents[number]>>>
   >
+  private readonly inProgressDispatchByEventId: Map<string, Promise<void>>
   private readonly inProgressBackgroundHandlerByEventId: Map<string, Promise<void>>
   private isDisposed = false
 
@@ -74,6 +75,7 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
       resolveHandlerSpy<CommonEventDefinitionConsumerSchemaType<SupportedEvents[number]>>(options)
 
     this.eventHandlerMap = new Map()
+    this.inProgressDispatchByEventId = new Map()
     this.inProgressBackgroundHandlerByEventId = new Map()
   }
 
@@ -89,25 +91,30 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
   }
 
   /**
-   * Waits for background handlers to settle, then stops accepting events.
+   * Waits for accepted events to finish being dispatched, then stops accepting new ones.
    *
-   * Background handlers can register while the drain is already running, either because their
-   * `emit()` was still awaiting foreground handlers when the drain started, or because a background
-   * handler emits an event of its own. A single pass over the map would miss those, so we keep
-   * draining until it stays empty, bounded so that an endless chain of events cannot hold shutdown
-   * open forever.
+   * Both maps are drained: an event is only in `inProgressBackgroundHandlerByEventId` once its
+   * foreground handlers are done, so mid-foreground dispatches are tracked separately. Re-checked
+   * until empty, since handlers can emit events of their own, and bounded so an endless chain
+   * cannot hold shutdown open.
    */
   public async dispose(): Promise<void> {
     for (let pass = 0; pass < MAX_DISPOSE_DRAIN_PASSES; pass++) {
-      if (this.inProgressBackgroundHandlerByEventId.size === 0) break
+      const pending = [
+        ...this.inProgressDispatchByEventId.values(),
+        ...this.inProgressBackgroundHandlerByEventId.values(),
+      ]
+      if (pending.length === 0) break
 
-      await Promise.all(this.inProgressBackgroundHandlerByEventId.values())
+      await Promise.all(pending)
     }
 
-    if (this.inProgressBackgroundHandlerByEventId.size > 0) {
+    const pendingCount =
+      this.inProgressDispatchByEventId.size + this.inProgressBackgroundHandlerByEventId.size
+    if (pendingCount > 0) {
       this.logger.error(
-        { pendingBackgroundHandlers: this.inProgressBackgroundHandlerByEventId.size },
-        `Background event handlers still pending after ${MAX_DISPOSE_DRAIN_PASSES} drain passes, giving up on them`,
+        { pendingEventDispatches: pendingCount },
+        `Event dispatches still pending after ${MAX_DISPOSE_DRAIN_PASSES} drain passes, giving up on them`,
       )
     }
 
@@ -115,6 +122,7 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
     // rather than finding an empty handler map and being silently discarded.
     this.isDisposed = true
 
+    this.inProgressDispatchByEventId.clear()
     this.inProgressBackgroundHandlerByEventId.clear()
     this.eventHandlerMap.clear()
     this._handlerSpy?.clear()
@@ -211,6 +219,28 @@ export class DomainEventEmitter<SupportedEvents extends CommonEventDefinition[]>
     const eventHandlers = this.eventHandlerMap.get(event.type)
     if (!eventHandlers) return
 
+    const dispatch = this.executeHandlers(event, eventHandlers)
+    /**
+     * Registering it so that when dispose is executed before we get to background handler, we still finish processing
+     */
+    this.inProgressDispatchByEventId.set(
+      event.id,
+      dispatch.catch(() => {}),
+    )
+
+    try {
+      await dispatch
+    } finally {
+      this.inProgressDispatchByEventId.delete(event.id)
+    }
+  }
+
+  private async executeHandlers<SupportedEvent extends SupportedEvents[number]>(
+    event: CommonEventDefinitionConsumerSchemaType<SupportedEvent>,
+    eventHandlers: Handlers<
+      EventHandler<CommonEventDefinitionConsumerSchemaType<SupportedEvents[number]>>
+    >,
+  ): Promise<void> {
     for (const handler of eventHandlers.foreground) {
       await this.executeEventHandler(event, handler, false)
     }


### PR DESCRIPTION
## What

1. `emit()` throws `InternalError { errorCode: 'EVENT_EMITTER_DISPOSED' }` after `dispose()`, instead of resolving successfully having invoked nothing.
2. `dispose()` waits for the full dispatch of every accepted event, not only for background handlers that already started, re-checking until nothing is pending.

## Why

`dispose()` clears `eventHandlerMap`, after which `handleEvent`'s `if (!eventHandlers) return` makes every later `emit()` a no-op — no listener runs, including one that forwards the event onwards, such as an SNS publisher registered via `onAny`. `emit()` still resolves and returns the event, so the caller cannot tell. This happens whenever a queue consumer or job worker's in-flight work outlives the emitter's disposal: the job completes successfully, its event reaches nothing, and there is no error to find. Throwing lets the caller fail and be retried.

Disposal also under-waited. It awaited a single snapshot of `inProgressBackgroundHandlerByEventId`, but an event only enters that map once its foreground handlers finish — so an `emit()` still in its foreground phase was invisible, and disposal could return just before that event started its background handlers. Chained emits from background handlers were missed for the same reason. Dispatches are now tracked from the point `emit()` is accepted, both maps drain together, and the drain repeats until empty (bounded, so an endless chain cannot hold shutdown open).

## Breaking

`emit()` after `dispose()` rejects instead of resolving, so anything that disposes then emits — including test teardown — will see `EVENT_EMITTER_DISPOSED`. `dispose()` stays terminal, with no reset path. It now also waits for in-flight foreground handlers, adding their latency to shutdown.
